### PR TITLE
feat: add keyword.operator.bitwise.moonbit to support bitwise operator

### DIFF
--- a/grammars/moonbit.tmLanguage.json
+++ b/grammars/moonbit.tmLanguage.json
@@ -1,342 +1,346 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "moonbit",
-  "scopeName": "source.moonbit",
-  "fileTypes": ["mbt"],
-  "patterns": [
-    {
-      "include": "#strings"
-    },
-    {
-      "include": "#comments"
-    },
-    {
-      "include": "#constants"
-    },
-    {
-      "include": "#keywords"
-    },
-    {
-      "include": "#functions"
-    },
-    {
-      "include": "#support"
-    },
-    {
-      "include": "#types"
-    },
-    {
-      "include": "#modules"
-    },
-    {
-      "include": "#variables"
-    }
-  ],
-  "repository": {
-    "support": {
-      "patterns": [
-        {
-          "name": "support.class.moonbit",
-          "match": "\\b(Eq|Compare|Hash|Show|Default|ToJson|FromJson)\\b"
-        }
-      ]
-    },
-    "keywords": {
-      "patterns": [
-        {
-          "name": "keyword.control.moonbit",
-          "match": "\\b(guard|if|while|break|continue|return|try|catch|except|raise|match|else|as|in|loop|for)\\b"
-        },
-        {
-          "name": "keyword.moonbit",
-          "match": "\\b(type!|(type|typealias|let|const|enum|struct|import|trait|derive|test|impl|with)\\b)"
-        },
-        {
-          "name": "variable.language.moonbit",
-          "match": "\\b(self)\\b"
-        },
-        {
-          "name": "storage.modifier.moonbit",
-          "match": "\\b(mut|pub|priv|readonly|extern)\\b"
-        },
-        {
-          "name": "storage.type.function.arrow.moonbit",
-          "match": "->"
-        },
-        {
-          "name": "storage.type.function.arrow.moonbit",
-          "match": "=>"
-        },
-        {
-          "name": "keyword.operator.assignment.moonbit",
-          "match": "="
-        },
-        {
-          "name": "keyword.operator.other.moonbit",
-          "match": "\\|>"
-        },
-        {
-          "name": "keyword.operator.comparison.moonbit",
-          "match": "(===|==|!=|>=|<=|(?<!-)>|<)"
-        },
-        {
-          "name": "keyword.operator.logical.moonbit",
-          "match": "(\\bnot\\b|&&|\\|\\|)"
-        },
-        {
-          "name": "keyword.operator.math.moonbit",
-          "match": "(\\+|-(?!>)|\\*|%|/)"
-        }
-      ]
-    },
-    "comments": {
-      "patterns": [
-        {
-          "name": "comment.line",
-          "match": "//[^/].*"
-        },
-        {
-          "name": "comment.block.documentation.moonbit",
-          "begin": "///",
-          "while": "///",
-          "patterns": [
-            {
-              "begin": "\\s*```",
-              "end": "\\s*```",
-              "beginCaptures": {
-                "0": { "name": "markup.fenced_code.block.markdown" }
-              },
-              "endCaptures": {
-                "0": { "name": "markup.fenced_code.block.markdown" }
-              },
-              "patterns": [{ "include": "$self" }],
-              "name": "meta.embedded.line.moonbit"
-            },
-            { "name": "comment.block.documentation.moonbit", "match": ".*" }
-          ]
-        }
-      ]
-    },
-    "interpolation": {
-      "patterns": [
-        {
-          "begin": "\\\\{",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.section.embedded.begin.moonbit"
-            }
-          },
-          "contentName": "source.moonbit",
-          "end": "}",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.section.embedded.end.moonbit"
-            }
-          },
-          "patterns": [
-            {
-              "include": "$self"
-            }
-          ],
-          "name": "meta.embedded.line.moonbit"
-        }
-      ]
-    },
-    "escape": {
-      "patterns": [
-        {
-          "match": "\\\\[0\\\\tnrb\"']",
-          "name": "constant.character.escape.moonbit"
-        },
-        {
-          "name": "constant.character.escape.moonbit",
-          "match": "\\\\x[0-9a-fA-F]{2}"
-        },
-        {
-          "name": "constant.character.escape.moonbit",
-          "match": "\\\\o[0-3][0-7]{2}"
-        },
-        {
-          "match": "\\\\u[0-9a-fA-F]{4}",
-          "name": "constant.character.escape.unicode.moonbit"
-        },
-        {
-          "match": "\\\\u{[0-9a-fA-F]*}",
-          "name": "constant.character.escape.unicode.moonbit"
-        }
-      ]
-    },
-    "strings": {
-      "patterns": [
-        {
-          "name": "string.line",
-          "match": "(#\\|).*",
-          "captures": {
-            "1": {
-              "name": "keyword.operator.other.moonbit"
-            }
-          }
-        },
-        {
-          "name": "string.line",
-          "match": "(\\$\\|)(.*)",
-          "captures": {
-            "1": {
-              "name": "keyword.operator.other.moonbit"
-            },
-            "2": {
-              "patterns": [
-                {
-                  "include": "#escape"
-                },
-                {
-                  "include": "#interpolation"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name": "string.quoted.single.moonbit",
-          "begin": "'",
-          "end": "'",
-          "patterns": [
-            {
-              "include": "#escape"
-            }
-          ]
-        },
-        {
-          "name": "string.quoted.double.moonbit",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [
-            {
-              "include": "#escape"
-            },
-            {
-              "include": "#interpolation"
-            }
-          ]
-        }
-      ]
-    },
-    "constants": {
-      "patterns": [
-        {
-          "name": "constant.numeric.moonbit",
-          "match": "\\b\\d(\\d|_)*(?!\\.)(U)?(L)?\\b"
-        },
-        {
-          "name": "constant.numeric.moonbit",
-          "match": "(?<=\\.)\\d((?=\\.)|\\b)"
-        },
-        {
-          "name": "constant.numeric.moonbit",
-          "match": "\\b\\d+(\\.)\\d+\\b"
-        },
-        {
-          "name": "constant.numeric.moonbit",
-          "match": "\\b0[XxOoBb][\\dAaBbCcDdEeFf]+(U)?(L)?\\b"
-        },
-        {
-          "name": "constant.language.moonbit",
-          "match": "\\b(true|false|\\(\\))\\b"
-        }
-      ]
-    },
-    "modules": {
-      "patterns": [
-        {
-          "name": "entity.name.namespace.moonbit",
-          "match": "@[A-Za-z][A-Za-z0-9_/]*"
-        }
-      ]
-    },
-    "variables": {
-      "patterns": [
-        {
-          "comment": "variables",
-          "name": "variable.other.moonbit",
-          "match": "\\b(?<!\\.|::)[a-z_][a-zA-Z0-9_]*\\b"
-        }
-      ]
-    },
-    "types": {
-      "patterns": [
-        {
-          "comment": "types",
-          "name": "entity.name.type.moonbit",
-          "match": "\\b(?<!@)[A-Z][A-Za-z0-9_]*((\\?)+|\\b)"
-        }
-      ]
-    },
-    "functions": {
-      "patterns": [
-        {
-          "comment": "function/method definitions",
-          "match": "\\b(fn)\\b\\s*(?:([A-Z][A-Za-z0-9_]*)::)?([a-z0-9_][A-Za-z0-9_]*)?\\b",
-          "captures": {
-            "1": {
-              "name": "keyword.moonbit"
-            },
-            "2": {
-              "name": "entity.name.type.moonbit"
-            },
-            "3": {
-              "name": "entity.name.function.moonbit"
-            }
-          }
-        },
-        {
-          "comment": "function/method calls, chaining",
-          "name": "meta.function.call.moonbit",
-          "begin": "(?!\\bfn\\s+)(?:\\.|::)?([a-z0-9_][A-Za-z0-9_]*(\\!|\\?)?)(\\()",
-          "beginCaptures": {
-            "1": {
-              "name": "entity.name.function.moonbit"
-            },
-            "2": {
-              "name": "punctuation.brackets.round.moonbit"
-            }
-          },
-          "end": "\\)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.brackets.round.moonbit"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#comments"
-            },
-            {
-              "include": "#constants"
-            },
-            {
-              "include": "#functions"
-            },
-            {
-              "include": "#support"
-            },
-            {
-              "include": "#types"
-            },
-            {
-              "include": "#keywords"
-            },
-            {
-              "include": "#modules"
-            },
-            {
-              "include": "#strings"
-            },
-            {
-              "include": "#variables"
-            }
-          ]
-        }
-      ]
-    }
-  }
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "moonbit",
+	"scopeName": "source.moonbit",
+	"fileTypes": ["mbt"],
+	"patterns": [
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#constants"
+		},
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#functions"
+		},
+		{
+			"include": "#support"
+		},
+		{
+			"include": "#types"
+		},
+		{
+			"include": "#modules"
+		},
+		{
+			"include": "#variables"
+		}
+	],
+	"repository": {
+		"support": {
+			"patterns": [
+				{
+					"name": "support.class.moonbit",
+					"match": "\\b(Eq|Compare|Hash|Show|Default|ToJson|FromJson)\\b"
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"name": "keyword.control.moonbit",
+					"match": "\\b(guard|if|while|break|continue|return|try|catch|except|raise|match|else|as|in|loop|for)\\b"
+				},
+				{
+					"name": "keyword.moonbit",
+					"match": "\\b(type!|(type|typealias|let|const|enum|struct|import|trait|derive|test|impl|with)\\b)"
+				},
+				{
+					"name": "variable.language.moonbit",
+					"match": "\\b(self)\\b"
+				},
+				{
+					"name": "storage.modifier.moonbit",
+					"match": "\\b(mut|pub|priv|readonly|extern)\\b"
+				},
+				{
+					"name": "storage.type.function.arrow.moonbit",
+					"match": "->"
+				},
+				{
+					"name": "storage.type.function.arrow.moonbit",
+					"match": "=>"
+				},
+				{
+					"name": "keyword.operator.assignment.moonbit",
+					"match": "="
+				},
+				{
+					"name": "keyword.operator.other.moonbit",
+					"match": "\\|>"
+				},
+				{
+					"name": "keyword.operator.comparison.moonbit",
+					"match": "(===|==|!=|>=|<=|(?<!-)(?<!|)>(?!>)|<(?!<))"
+				},
+				{
+					"name": "keyword.operator.logical.moonbit",
+					"match": "(\\bnot\\b|&&|\\|\\|)"
+				},
+				{
+					"name": "keyword.operator.bitwise.moonbit",
+					"match": "(\\|(?!\\|)(?!>)|&(?!&)|\\^|<<|>>)"
+				},
+				{
+					"name": "keyword.operator.math.moonbit",
+					"match": "(\\+|-(?!>)|\\*|%|/)"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line",
+					"match": "//[^/].*"
+				},
+				{
+					"name": "comment.block.documentation.moonbit",
+					"begin": "///",
+					"while": "///",
+					"patterns": [
+						{
+							"begin": "\\s*```",
+							"end": "\\s*```",
+							"beginCaptures": {
+								"0": { "name": "markup.fenced_code.block.markdown" }
+							},
+							"endCaptures": {
+								"0": { "name": "markup.fenced_code.block.markdown" }
+							},
+							"patterns": [{ "include": "$self" }],
+							"name": "meta.embedded.line.moonbit"
+						},
+						{ "name": "comment.block.documentation.moonbit", "match": ".*" }
+					]
+				}
+			]
+		},
+		"interpolation": {
+			"patterns": [
+				{
+					"begin": "\\\\{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.embedded.begin.moonbit"
+						}
+					},
+					"contentName": "source.moonbit",
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.embedded.end.moonbit"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					],
+					"name": "meta.embedded.line.moonbit"
+				}
+			]
+		},
+		"escape": {
+			"patterns": [
+				{
+					"match": "\\\\[0\\\\tnrb\"']",
+					"name": "constant.character.escape.moonbit"
+				},
+				{
+					"name": "constant.character.escape.moonbit",
+					"match": "\\\\x[0-9a-fA-F]{2}"
+				},
+				{
+					"name": "constant.character.escape.moonbit",
+					"match": "\\\\o[0-3][0-7]{2}"
+				},
+				{
+					"match": "\\\\u[0-9a-fA-F]{4}",
+					"name": "constant.character.escape.unicode.moonbit"
+				},
+				{
+					"match": "\\\\u{[0-9a-fA-F]*}",
+					"name": "constant.character.escape.unicode.moonbit"
+				}
+			]
+		},
+		"strings": {
+			"patterns": [
+				{
+					"name": "string.line",
+					"match": "(#\\|).*",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.other.moonbit"
+						}
+					}
+				},
+				{
+					"name": "string.line",
+					"match": "(\\$\\|)(.*)",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.other.moonbit"
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#escape"
+								},
+								{
+									"include": "#interpolation"
+								}
+							]
+						}
+					}
+				},
+				{
+					"name": "string.quoted.single.moonbit",
+					"begin": "'",
+					"end": "'",
+					"patterns": [
+						{
+							"include": "#escape"
+						}
+					]
+				},
+				{
+					"name": "string.quoted.double.moonbit",
+					"begin": "\"",
+					"end": "\"",
+					"patterns": [
+						{
+							"include": "#escape"
+						},
+						{
+							"include": "#interpolation"
+						}
+					]
+				}
+			]
+		},
+		"constants": {
+			"patterns": [
+				{
+					"name": "constant.numeric.moonbit",
+					"match": "\\b\\d(\\d|_)*(?!\\.)(U)?(L)?\\b"
+				},
+				{
+					"name": "constant.numeric.moonbit",
+					"match": "(?<=\\.)\\d((?=\\.)|\\b)"
+				},
+				{
+					"name": "constant.numeric.moonbit",
+					"match": "\\b\\d+(\\.)\\d+\\b"
+				},
+				{
+					"name": "constant.numeric.moonbit",
+					"match": "\\b0[XxOoBb][\\dAaBbCcDdEeFf]+(U)?(L)?\\b"
+				},
+				{
+					"name": "constant.language.moonbit",
+					"match": "\\b(true|false|\\(\\))\\b"
+				}
+			]
+		},
+		"modules": {
+			"patterns": [
+				{
+					"name": "entity.name.namespace.moonbit",
+					"match": "@[A-Za-z][A-Za-z0-9_/]*"
+				}
+			]
+		},
+		"variables": {
+			"patterns": [
+				{
+					"comment": "variables",
+					"name": "variable.other.moonbit",
+					"match": "\\b(?<!\\.|::)[a-z_][a-zA-Z0-9_]*\\b"
+				}
+			]
+		},
+		"types": {
+			"patterns": [
+				{
+					"comment": "types",
+					"name": "entity.name.type.moonbit",
+					"match": "\\b(?<!@)[A-Z][A-Za-z0-9_]*((\\?)+|\\b)"
+				}
+			]
+		},
+		"functions": {
+			"patterns": [
+				{
+					"comment": "function/method definitions",
+					"match": "\\b(fn)\\b\\s*(?:([A-Z][A-Za-z0-9_]*)::)?([a-z0-9_][A-Za-z0-9_]*)?\\b",
+					"captures": {
+						"1": {
+							"name": "keyword.moonbit"
+						},
+						"2": {
+							"name": "entity.name.type.moonbit"
+						},
+						"3": {
+							"name": "entity.name.function.moonbit"
+						}
+					}
+				},
+				{
+					"comment": "function/method calls, chaining",
+					"name": "meta.function.call.moonbit",
+					"begin": "(?!\\bfn\\s+)(?:\\.|::)?([a-z0-9_][A-Za-z0-9_]*(\\!|\\?)?)(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.moonbit"
+						},
+						"2": {
+							"name": "punctuation.brackets.round.moonbit"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.brackets.round.moonbit"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#constants"
+						},
+						{
+							"include": "#functions"
+						},
+						{
+							"include": "#support"
+						},
+						{
+							"include": "#types"
+						},
+						{
+							"include": "#keywords"
+						},
+						{
+							"include": "#modules"
+						},
+						{
+							"include": "#strings"
+						},
+						{
+							"include": "#variables"
+						}
+					]
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
add keyword.operator.bitwise.moonbit for &, ^, |, << and >> (issue #3) 
fix miss match |>, << and >> in keyword.operator.comparison.moonbit
