### PR TITLE
add keyword.operator.bitwise.moonbit for &, ^, |, << and >> 

### DIFF
--- a/grammars/moonbit.tmLanguage.json
+++ b/grammars/moonbit.tmLanguage.json
@@ -77,11 +77,15 @@
         },
         {
           "name": "keyword.operator.comparison.moonbit",
-          "match": "(===|==|!=|>=|<=|(?<!-)>|<)"
+          "match": "(===|==|!=|>=|<=|(?<!-)(?<!\\|)>(?!>)|<(?!<))"
         },
         {
           "name": "keyword.operator.logical.moonbit",
           "match": "(\\bnot\\b|&&|\\|\\|)"
+        },
+        {
+          "name": "keyword.operator.bitwise.moonbit",
+          "match": "(\\|(?!\\|)(?!>)|&(?!&)|\\^|<<|>>)"
         },
         {
           "name": "keyword.operator.math.moonbit",


### PR DESCRIPTION
add keyword.operator.bitwise.moonbit for &, ^, |, << and >> (related #3)
fix miss match |>, << and >> in keyword.operator.comparison.moonbit (fix bug in #4)