### PR TITLE
[codex] Use variable property scope for MoonBit fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules
-artifacts/*
-!artifacts/previews/
-!artifacts/previews/**
+AGENTS.md

--- a/artifacts/previews/async-cat-main.svg
+++ b/artifacts/previews/async-cat-main.svg
@@ -48,13 +48,13 @@
     <text x="189.0" y="153" fill="#3B3B3B" font-size="15"> </text>
     <text x="197.6" y="153" fill="#267F99" font-size="15">@stdio</text>
     <text x="249.2" y="153" fill="#3B3B3B" font-size="15">.</text>
-    <text x="257.8" y="153" fill="#3B3B3B" font-size="15">stdout</text>
+    <text x="257.8" y="153" fill="#001080" font-size="15">stdout</text>
     <text x="309.4" y="153" fill="#3B3B3B" font-size="15">.</text>
     <text x="318.0" y="153" fill="#795E26" font-size="15">write_reader</text>
     <text x="421.2" y="153" fill="#3B3B3B" font-size="15">(</text>
     <text x="429.8" y="153" fill="#267F99" font-size="15">@stdio</text>
     <text x="481.4" y="153" fill="#3B3B3B" font-size="15">.</text>
-    <text x="490.0" y="153" fill="#3B3B3B" font-size="15">stdin</text>
+    <text x="490.0" y="153" fill="#001080" font-size="15">stdin</text>
     <text x="533.0" y="153" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
     <text x="60.0" y="175" fill="#3B3B3B" font-size="15">    </text>
@@ -96,13 +96,13 @@
     <text x="60.0" y="241" fill="#3B3B3B" font-size="15">          </text>
     <text x="146.0" y="241" fill="#267F99" font-size="15">@stdio</text>
     <text x="197.6" y="241" fill="#3B3B3B" font-size="15">.</text>
-    <text x="206.2" y="241" fill="#3B3B3B" font-size="15">stdout</text>
+    <text x="206.2" y="241" fill="#001080" font-size="15">stdout</text>
     <text x="257.8" y="241" fill="#3B3B3B" font-size="15">.</text>
     <text x="266.4" y="241" fill="#795E26" font-size="15">write_reader</text>
     <text x="369.6" y="241" fill="#3B3B3B" font-size="15">(</text>
     <text x="378.2" y="241" fill="#267F99" font-size="15">@stdio</text>
     <text x="429.8" y="241" fill="#3B3B3B" font-size="15">.</text>
-    <text x="438.4" y="241" fill="#3B3B3B" font-size="15">stdin</text>
+    <text x="438.4" y="241" fill="#001080" font-size="15">stdin</text>
     <text x="481.4" y="241" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
     <text x="60.0" y="263" fill="#3B3B3B" font-size="15">        </text>
@@ -143,7 +143,7 @@
     <text x="60.0" y="329" fill="#3B3B3B" font-size="15">          </text>
     <text x="146.0" y="329" fill="#267F99" font-size="15">@stdio</text>
     <text x="197.6" y="329" fill="#3B3B3B" font-size="15">.</text>
-    <text x="206.2" y="329" fill="#3B3B3B" font-size="15">stdout</text>
+    <text x="206.2" y="329" fill="#001080" font-size="15">stdout</text>
     <text x="257.8" y="329" fill="#3B3B3B" font-size="15">.</text>
     <text x="266.4" y="329" fill="#795E26" font-size="15">write_reader</text>
     <text x="369.6" y="329" fill="#3B3B3B" font-size="15">(</text>

--- a/artifacts/previews/async-semaphore.svg
+++ b/artifacts/previews/async-semaphore.svg
@@ -211,13 +211,13 @@
     <text x="94.4" y="703" fill="#3B3B3B" font-size="15"> </text>
     <text x="103.0" y="703" fill="#001080" font-size="15">self</text>
     <text x="137.4" y="703" fill="#3B3B3B" font-size="15">.</text>
-    <text x="146.0" y="703" fill="#3B3B3B" font-size="15">value</text>
+    <text x="146.0" y="703" fill="#001080" font-size="15">value</text>
     <text x="189.0" y="703" fill="#3B3B3B" font-size="15"> </text>
     <text x="197.6" y="703" fill="#000000" font-size="15">&gt;=</text>
     <text x="214.8" y="703" fill="#3B3B3B" font-size="15"> </text>
     <text x="223.4" y="703" fill="#001080" font-size="15">self</text>
     <text x="257.8" y="703" fill="#3B3B3B" font-size="15">.</text>
-    <text x="266.4" y="703" fill="#3B3B3B" font-size="15">size</text>
+    <text x="266.4" y="703" fill="#001080" font-size="15">size</text>
     <text x="300.8" y="703" fill="#3B3B3B" font-size="15"> </text>
     <text x="309.4" y="703" fill="#3B3B3B" font-size="15">{</text>
     <text x="26" y="725" fill="#6E7681" font-size="15">32</text>
@@ -237,7 +237,7 @@
     <text x="120.2" y="769" fill="#3B3B3B" font-size="15"> </text>
     <text x="128.8" y="769" fill="#001080" font-size="15">self</text>
     <text x="163.2" y="769" fill="#3B3B3B" font-size="15">.</text>
-    <text x="171.8" y="769" fill="#3B3B3B" font-size="15">waiters</text>
+    <text x="171.8" y="769" fill="#001080" font-size="15">waiters</text>
     <text x="232.0" y="769" fill="#3B3B3B" font-size="15">.</text>
     <text x="240.6" y="769" fill="#795E26" font-size="15">pop_front</text>
     <text x="318.0" y="769" fill="#3B3B3B" font-size="15">(</text>
@@ -257,7 +257,7 @@
     <text x="111.6" y="791" fill="#3B3B3B" font-size="15"> </text>
     <text x="120.2" y="791" fill="#001080" font-size="15">waiter</text>
     <text x="171.8" y="791" fill="#3B3B3B" font-size="15">.</text>
-    <text x="180.4" y="791" fill="#3B3B3B" font-size="15">coro</text>
+    <text x="180.4" y="791" fill="#001080" font-size="15">coro</text>
     <text x="214.8" y="791" fill="#3B3B3B" font-size="15"> </text>
     <text x="223.4" y="791" fill="#0000FF" font-size="15">is</text>
     <text x="240.6" y="791" fill="#3B3B3B" font-size="15"> </text>
@@ -271,7 +271,7 @@
     <text x="60.0" y="813" fill="#3B3B3B" font-size="15">      </text>
     <text x="111.6" y="813" fill="#001080" font-size="15">waiter</text>
     <text x="163.2" y="813" fill="#3B3B3B" font-size="15">.</text>
-    <text x="171.8" y="813" fill="#3B3B3B" font-size="15">acquired</text>
+    <text x="171.8" y="813" fill="#001080" font-size="15">acquired</text>
     <text x="240.6" y="813" fill="#3B3B3B" font-size="15"> </text>
     <text x="249.2" y="813" fill="#000000" font-size="15">=</text>
     <text x="257.8" y="813" fill="#3B3B3B" font-size="15"> </text>
@@ -300,7 +300,7 @@
     <text x="60.0" y="923" fill="#3B3B3B" font-size="15">    </text>
     <text x="94.4" y="923" fill="#001080" font-size="15">self</text>
     <text x="128.8" y="923" fill="#3B3B3B" font-size="15">.</text>
-    <text x="137.4" y="923" fill="#3B3B3B" font-size="15">value</text>
+    <text x="137.4" y="923" fill="#001080" font-size="15">value</text>
     <text x="180.4" y="923" fill="#3B3B3B" font-size="15"> </text>
     <text x="189.0" y="923" fill="#000000" font-size="15">+=</text>
     <text x="206.2" y="923" fill="#3B3B3B" font-size="15"> </text>
@@ -345,7 +345,7 @@
     <text x="94.4" y="1077" fill="#3B3B3B" font-size="15"> </text>
     <text x="103.0" y="1077" fill="#001080" font-size="15">self</text>
     <text x="137.4" y="1077" fill="#3B3B3B" font-size="15">.</text>
-    <text x="146.0" y="1077" fill="#3B3B3B" font-size="15">value</text>
+    <text x="146.0" y="1077" fill="#001080" font-size="15">value</text>
     <text x="189.0" y="1077" fill="#3B3B3B" font-size="15"> </text>
     <text x="197.6" y="1077" fill="#000000" font-size="15">&gt;</text>
     <text x="206.2" y="1077" fill="#3B3B3B" font-size="15"> </text>
@@ -356,7 +356,7 @@
     <text x="60.0" y="1099" fill="#3B3B3B" font-size="15">    </text>
     <text x="94.4" y="1099" fill="#001080" font-size="15">self</text>
     <text x="128.8" y="1099" fill="#3B3B3B" font-size="15">.</text>
-    <text x="137.4" y="1099" fill="#3B3B3B" font-size="15">value</text>
+    <text x="137.4" y="1099" fill="#001080" font-size="15">value</text>
     <text x="180.4" y="1099" fill="#3B3B3B" font-size="15"> </text>
     <text x="189.0" y="1099" fill="#000000" font-size="15">-=</text>
     <text x="206.2" y="1099" fill="#3B3B3B" font-size="15"> </text>
@@ -401,7 +401,7 @@
     <text x="60.0" y="1165" fill="#3B3B3B" font-size="15">    </text>
     <text x="94.4" y="1165" fill="#001080" font-size="15">self</text>
     <text x="128.8" y="1165" fill="#3B3B3B" font-size="15">.</text>
-    <text x="137.4" y="1165" fill="#3B3B3B" font-size="15">waiters</text>
+    <text x="137.4" y="1165" fill="#001080" font-size="15">waiters</text>
     <text x="197.6" y="1165" fill="#3B3B3B" font-size="15">.</text>
     <text x="206.2" y="1165" fill="#795E26" font-size="15">push_back</text>
     <text x="283.6" y="1165" fill="#3B3B3B" font-size="15">(</text>
@@ -426,7 +426,7 @@
     <text x="146.0" y="1209" fill="#3B3B3B" font-size="15"> </text>
     <text x="154.6" y="1209" fill="#001080" font-size="15">waiter</text>
     <text x="206.2" y="1209" fill="#3B3B3B" font-size="15">.</text>
-    <text x="214.8" y="1209" fill="#3B3B3B" font-size="15">acquired</text>
+    <text x="214.8" y="1209" fill="#001080" font-size="15">acquired</text>
     <text x="283.6" y="1209" fill="#3B3B3B" font-size="15"> </text>
     <text x="292.2" y="1209" fill="#0000FF" font-size="15">=&gt;</text>
     <text x="309.4" y="1209" fill="#3B3B3B" font-size="15"> </text>
@@ -443,7 +443,7 @@
     <text x="60.0" y="1253" fill="#3B3B3B" font-size="15">        </text>
     <text x="128.8" y="1253" fill="#001080" font-size="15">waiter</text>
     <text x="180.4" y="1253" fill="#3B3B3B" font-size="15">.</text>
-    <text x="189.0" y="1253" fill="#3B3B3B" font-size="15">coro</text>
+    <text x="189.0" y="1253" fill="#001080" font-size="15">coro</text>
     <text x="223.4" y="1253" fill="#3B3B3B" font-size="15"> </text>
     <text x="232.0" y="1253" fill="#000000" font-size="15">=</text>
     <text x="240.6" y="1253" fill="#3B3B3B" font-size="15"> </text>

--- a/artifacts/previews/async-task.svg
+++ b/artifacts/previews/async-task.svg
@@ -78,7 +78,7 @@
     <text x="60.0" y="307" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="307" fill="#001080" font-size="15">self</text>
     <text x="111.6" y="307" fill="#3B3B3B" font-size="15">.</text>
-    <text x="120.2" y="307" fill="#3B3B3B" font-size="15">coro</text>
+    <text x="120.2" y="307" fill="#001080" font-size="15">coro</text>
     <text x="154.6" y="307" fill="#3B3B3B" font-size="15">.</text>
     <text x="163.2" y="307" fill="#795E26" font-size="15">wait</text>
     <text x="197.6" y="307" fill="#3B3B3B" font-size="15">(</text>
@@ -87,9 +87,9 @@
     <text x="60.0" y="329" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="329" fill="#001080" font-size="15">self</text>
     <text x="111.6" y="329" fill="#3B3B3B" font-size="15">.</text>
-    <text x="120.2" y="329" fill="#3B3B3B" font-size="15">value</text>
+    <text x="120.2" y="329" fill="#001080" font-size="15">value</text>
     <text x="163.2" y="329" fill="#3B3B3B" font-size="15">.</text>
-    <text x="171.8" y="329" fill="#3B3B3B" font-size="15">val</text>
+    <text x="171.8" y="329" fill="#001080" font-size="15">val</text>
     <text x="197.6" y="329" fill="#3B3B3B" font-size="15">.</text>
     <text x="206.2" y="329" fill="#795E26" font-size="15">unwrap</text>
     <text x="257.8" y="329" fill="#3B3B3B" font-size="15">(</text>
@@ -135,7 +135,7 @@
     <text x="60.0" y="461" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="461" fill="#001080" font-size="15">self</text>
     <text x="111.6" y="461" fill="#3B3B3B" font-size="15">.</text>
-    <text x="120.2" y="461" fill="#3B3B3B" font-size="15">coro</text>
+    <text x="120.2" y="461" fill="#001080" font-size="15">coro</text>
     <text x="154.6" y="461" fill="#3B3B3B" font-size="15">.</text>
     <text x="163.2" y="461" fill="#795E26" font-size="15">check_error</text>
     <text x="257.8" y="461" fill="#3B3B3B" font-size="15">(</text>
@@ -144,9 +144,9 @@
     <text x="60.0" y="483" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="483" fill="#001080" font-size="15">self</text>
     <text x="111.6" y="483" fill="#3B3B3B" font-size="15">.</text>
-    <text x="120.2" y="483" fill="#3B3B3B" font-size="15">value</text>
+    <text x="120.2" y="483" fill="#001080" font-size="15">value</text>
     <text x="163.2" y="483" fill="#3B3B3B" font-size="15">.</text>
-    <text x="171.8" y="483" fill="#3B3B3B" font-size="15">val</text>
+    <text x="171.8" y="483" fill="#001080" font-size="15">val</text>
     <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
     <text x="60.0" y="505" fill="#3B3B3B" font-size="15">}</text>
     <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
@@ -186,7 +186,7 @@
     <text x="60.0" y="615" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="615" fill="#001080" font-size="15">self</text>
     <text x="111.6" y="615" fill="#3B3B3B" font-size="15">.</text>
-    <text x="120.2" y="615" fill="#3B3B3B" font-size="15">coro</text>
+    <text x="120.2" y="615" fill="#001080" font-size="15">coro</text>
     <text x="154.6" y="615" fill="#3B3B3B" font-size="15">.</text>
     <text x="163.2" y="615" fill="#795E26" font-size="15">cancel</text>
     <text x="214.8" y="615" fill="#3B3B3B" font-size="15">(</text>

--- a/artifacts/previews/handwritten-imports-packages.svg
+++ b/artifacts/previews/handwritten-imports-packages.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="508" height="232" viewBox="0 0 508 232">
+<svg xmlns="http://www.w3.org/2000/svg" width="508" height="276" viewBox="0 0 508 276">
   <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
   <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
     <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
@@ -53,6 +53,28 @@
     <text x="292.2" y="175" fill="#3B3B3B" font-size="15">(</text>
     <text x="300.8" y="175" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
-    <text x="60.0" y="197" fill="#3B3B3B" font-size="15">}</text>
+    <text x="60.0" y="197" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="197" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="197" fill="#001080" font-size="15">pkg_field</text>
+    <text x="189.0" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="197" fill="#000000" font-size="15">=</text>
+    <text x="206.2" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="214.8" y="197" fill="#267F99" font-size="15">@pkg</text>
+    <text x="249.2" y="197" fill="#3B3B3B" font-size="15">.</text>
+    <text x="257.8" y="197" fill="#001080" font-size="15">filed</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="219" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="219" fill="#001080" font-size="15">type_field</text>
+    <text x="197.6" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="219" fill="#000000" font-size="15">=</text>
+    <text x="214.8" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="219" fill="#0000FF" font-size="15">type</text>
+    <text x="257.8" y="219" fill="#3B3B3B" font-size="15">.</text>
+    <text x="266.4" y="219" fill="#001080" font-size="15">field</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#3B3B3B" font-size="15">}</text>
   </g>
 </svg>

--- a/artifacts/previews/language-surface.svg
+++ b/artifacts/previews/language-surface.svg
@@ -202,13 +202,13 @@
     <text x="146.0" y="615" fill="#3B3B3B" font-size="15"> </text>
     <text x="154.6" y="615" fill="#001080" font-size="15">a</text>
     <text x="163.2" y="615" fill="#3B3B3B" font-size="15">.</text>
-    <text x="171.8" y="615" fill="#3B3B3B" font-size="15">x</text>
+    <text x="171.8" y="615" fill="#001080" font-size="15">x</text>
     <text x="180.4" y="615" fill="#3B3B3B" font-size="15"> </text>
     <text x="189.0" y="615" fill="#000000" font-size="15">-</text>
     <text x="197.6" y="615" fill="#3B3B3B" font-size="15"> </text>
     <text x="206.2" y="615" fill="#001080" font-size="15">b</text>
     <text x="214.8" y="615" fill="#3B3B3B" font-size="15">.</text>
-    <text x="223.4" y="615" fill="#3B3B3B" font-size="15">x</text>
+    <text x="223.4" y="615" fill="#001080" font-size="15">x</text>
     <text x="26" y="637" fill="#6E7681" font-size="15">28</text>
     <text x="60.0" y="637" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="637" fill="#0000FF" font-size="15">let</text>
@@ -219,13 +219,13 @@
     <text x="146.0" y="637" fill="#3B3B3B" font-size="15"> </text>
     <text x="154.6" y="637" fill="#001080" font-size="15">a</text>
     <text x="163.2" y="637" fill="#3B3B3B" font-size="15">.</text>
-    <text x="171.8" y="637" fill="#3B3B3B" font-size="15">y</text>
+    <text x="171.8" y="637" fill="#001080" font-size="15">y</text>
     <text x="180.4" y="637" fill="#3B3B3B" font-size="15"> </text>
     <text x="189.0" y="637" fill="#000000" font-size="15">-</text>
     <text x="197.6" y="637" fill="#3B3B3B" font-size="15"> </text>
     <text x="206.2" y="637" fill="#001080" font-size="15">b</text>
     <text x="214.8" y="637" fill="#3B3B3B" font-size="15">.</text>
-    <text x="223.4" y="637" fill="#3B3B3B" font-size="15">y</text>
+    <text x="223.4" y="637" fill="#001080" font-size="15">y</text>
     <text x="26" y="659" fill="#6E7681" font-size="15">29</text>
     <text x="60.0" y="659" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="659" fill="#3B3B3B" font-size="15">(</text>

--- a/grammars/moonbit.tmLanguage.json
+++ b/grammars/moonbit.tmLanguage.json
@@ -1000,7 +1000,7 @@
           "name": "punctuation.accessor.moonbit"
         },
         "2": {
-          "name": "entity.other.property.moonbit"
+          "name": "variable.other.property.moonbit"
         }
       }
     },

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -78,6 +78,18 @@ function addMoonBitTextMateOverlays(tmLanguage: TmGrammar): TmGrammar {
     },
   };
 
+  // VS Code themes commonly color variable.other.property, while
+  // entity.other.property is mostly used for markup attributes.
+  tmLanguage.repository['property-access']!.captures!['2'] = {
+    name: 'variable.other.property.moonbit',
+  };
+
+  if (tmLanguage.repository['optional-property-access']?.captures) {
+    tmLanguage.repository['optional-property-access'].captures['2'] = {
+      name: 'variable.other.property.moonbit',
+    };
+  }
+
   tmLanguage.repository['moonbit-impl-header'] = {
     name: 'meta.impl.header.moonbit',
     begin: '\\b(impl)\\b',

--- a/tests/fixtures/handwritten-imports-packages.mbt
+++ b/tests/fixtures/handwritten-imports-packages.mbt
@@ -11,4 +11,10 @@ fn use_imports {
 // ^^^^^^^^^^^ entity.name.function.moonbit
   let values = @moonbitlang/core/array.make(3, 0)
   values.length() |> ignore()
+  let pkg_field = @pkg.filed
+//                ^^^^ entity.name.namespace.moonbit
+//                     ^^^^^ variable.other.property.moonbit
+  let type_field = type.field
+//                 ^^^^ storage.type.moonbit
+//                      ^^^^^ variable.other.property.moonbit
 }


### PR DESCRIPTION
## Summary
- retarget MoonBit property access from `entity.other.property.moonbit` to `variable.other.property.moonbit`
- keep the rewrite in the MoonBit generation overlay with a comment explaining the VS Code theme compatibility reason
- add highlight fixture coverage for `@pkg.filed` and `type.field`
- refresh preview SVG artifacts after the scope change

## Validation
- `npm test`
