### PR TITLE
[codex] Fix MoonBit TextMate grammar generation

### DIFF
--- a/artifacts/previews/async-fs-text-file-test.svg
+++ b/artifacts/previews/async-fs-text-file-test.svg
@@ -1,0 +1,135 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="731" height="584" viewBox="0 0 731 584">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#008000" font-size="15">// Source: /Users/baozhiyuan/Workspace/async/src/fs/text_file_test.mbt</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#008000" font-size="15">// Copyright 2025 International Digital Economy Academy</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#008000" font-size="15">//</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#008000" font-size="15">// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#008000" font-size="15">// you may not use this file except in compliance with the License.</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#008000" font-size="15">// You may obtain a copy of the License at</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#008000" font-size="15">//</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#008000" font-size="15">//     http://www.apache.org/licenses/LICENSE-2.0</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#008000" font-size="15">//</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#008000" font-size="15">// Unless required by applicable law or agreed to in writing, software</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#008000" font-size="15">// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#008000" font-size="15">// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#008000" font-size="15">// See the License for the specific language governing permissions and</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#008000" font-size="15">// limitations under the License.</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="395" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="395" fill="#A31515" font-size="15">text file</text>
+    <text x="240.6" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="249.2" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="395" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#267F99" font-size="15">@async</text>
+    <text x="128.8" y="417" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="417" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="266.4" y="417" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="417" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="417" fill="#000000" font-size="15">&lt;|</text>
+    <text x="309.4" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="417" fill="#001080" font-size="15">root</text>
+    <text x="352.4" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="361.0" y="417" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="378.2" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="386.8" y="417" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="439" fill="#0000FF" font-size="15">let</text>
+    <text x="120.2" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="439" fill="#001080" font-size="15">path</text>
+    <text x="163.2" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="439" fill="#000000" font-size="15">=</text>
+    <text x="180.4" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="439" fill="#A31515" font-size="15">&quot;</text>
+    <text x="197.6" y="439" fill="#A31515" font-size="15">_build/basic_text_file_test</text>
+    <text x="429.8" y="439" fill="#A31515" font-size="15">&quot;</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="461" fill="#001080" font-size="15">root</text>
+    <text x="128.8" y="461" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="461" fill="#795E26" font-size="15">add_defer</text>
+    <text x="214.8" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="232.0" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="240.6" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="249.2" y="461" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="266.4" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="461" fill="#267F99" font-size="15">@fs</text>
+    <text x="300.8" y="461" fill="#3B3B3B" font-size="15">.</text>
+    <text x="309.4" y="461" fill="#795E26" font-size="15">remove</text>
+    <text x="361.0" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="369.6" y="461" fill="#001080" font-size="15">path</text>
+    <text x="404.0" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="412.6" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="483" fill="#267F99" font-size="15">@fs</text>
+    <text x="120.2" y="483" fill="#3B3B3B" font-size="15">.</text>
+    <text x="128.8" y="483" fill="#795E26" font-size="15">write_file</text>
+    <text x="214.8" y="483" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="483" fill="#001080" font-size="15">path</text>
+    <text x="257.8" y="483" fill="#3B3B3B" font-size="15">,</text>
+    <text x="266.4" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="483" fill="#A31515" font-size="15">&quot;</text>
+    <text x="283.6" y="483" fill="#A31515" font-size="15">abcd</text>
+    <text x="318.0" y="483" fill="#A31515" font-size="15">&quot;</text>
+    <text x="326.6" y="483" fill="#3B3B3B" font-size="15">,</text>
+    <text x="335.2" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="483" fill="#001080" font-size="15">create_mode</text>
+    <text x="438.4" y="483" fill="#000000" font-size="15">=</text>
+    <text x="447.0" y="483" fill="#267F99" font-size="15">CreateOrTruncate</text>
+    <text x="584.6" y="483" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="505" fill="#795E26" font-size="15">inspect</text>
+    <text x="154.6" y="505" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="505" fill="#267F99" font-size="15">@fs</text>
+    <text x="189.0" y="505" fill="#3B3B3B" font-size="15">.</text>
+    <text x="197.6" y="505" fill="#795E26" font-size="15">read_file</text>
+    <text x="275.0" y="505" fill="#3B3B3B" font-size="15">(</text>
+    <text x="283.6" y="505" fill="#001080" font-size="15">path</text>
+    <text x="318.0" y="505" fill="#3B3B3B" font-size="15">)</text>
+    <text x="326.6" y="505" fill="#3B3B3B" font-size="15">.</text>
+    <text x="335.2" y="505" fill="#795E26" font-size="15">text</text>
+    <text x="369.6" y="505" fill="#3B3B3B" font-size="15">(</text>
+    <text x="378.2" y="505" fill="#3B3B3B" font-size="15">)</text>
+    <text x="386.8" y="505" fill="#3B3B3B" font-size="15">,</text>
+    <text x="395.4" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="404.0" y="505" fill="#001080" font-size="15">content</text>
+    <text x="464.2" y="505" fill="#000000" font-size="15">=</text>
+    <text x="472.8" y="505" fill="#A31515" font-size="15">&quot;</text>
+    <text x="481.4" y="505" fill="#A31515" font-size="15">abcd</text>
+    <text x="515.8" y="505" fill="#A31515" font-size="15">&quot;</text>
+    <text x="524.4" y="505" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="60.0" y="527" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="527" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="549" fill="#6E7681" font-size="15">24</text>
+    <text x="60.0" y="549" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/async-mutex-test.svg
+++ b/artifacts/previews/async-mutex-test.svg
@@ -125,9 +125,9 @@
     <text x="197.6" y="549" fill="#3B3B3B" font-size="15">(</text>
     <text x="206.2" y="549" fill="#A31515" font-size="15">&quot;</text>
     <text x="214.8" y="549" fill="#A31515" font-size="15">task </text>
-    <text x="257.8" y="549" fill="#A31515" font-size="15">\{</text>
+    <text x="257.8" y="549" fill="#3B3B3B" font-size="15">\{</text>
     <text x="275.0" y="549" fill="#001080" font-size="15">i</text>
-    <text x="283.6" y="549" fill="#A31515" font-size="15">}</text>
+    <text x="283.6" y="549" fill="#3B3B3B" font-size="15">}</text>
     <text x="292.2" y="549" fill="#A31515" font-size="15"> acquired mutex</text>
     <text x="421.2" y="549" fill="#A31515" font-size="15">&quot;</text>
     <text x="429.8" y="549" fill="#3B3B3B" font-size="15">)</text>

--- a/artifacts/previews/async-mutex-test.svg
+++ b/artifacts/previews/async-mutex-test.svg
@@ -1,0 +1,810 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="972" height="2366" viewBox="0 0 972 2366">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#008000" font-size="15">// Source: /Users/baozhiyuan/Workspace/async/src/mutex_test.mbt</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#008000" font-size="15">// Copyright 2025 International Digital Economy Academy</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#008000" font-size="15">//</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#008000" font-size="15">// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#008000" font-size="15">// you may not use this file except in compliance with the License.</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#008000" font-size="15">// You may obtain a copy of the License at</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#008000" font-size="15">//</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#008000" font-size="15">//     http://www.apache.org/licenses/LICENSE-2.0</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#008000" font-size="15">//</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#008000" font-size="15">// Unless required by applicable law or agreed to in writing, software</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#008000" font-size="15">// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#008000" font-size="15">// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#008000" font-size="15">// See the License for the specific language governing permissions and</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#008000" font-size="15">// limitations under the License.</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="395" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="395" fill="#A31515" font-size="15">mutex basic</text>
+    <text x="257.8" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="266.4" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="395" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="417" fill="#001080" font-size="15">log</text>
+    <text x="137.4" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="417" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="417" fill="#3B3B3B" font-size="15">[</text>
+    <text x="171.8" y="417" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="439" fill="#267F99" font-size="15">@async</text>
+    <text x="128.8" y="439" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="439" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="266.4" y="439" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="439" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="439" fill="#000000" font-size="15">&lt;|</text>
+    <text x="309.4" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="439" fill="#001080" font-size="15">group</text>
+    <text x="361.0" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="369.6" y="439" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="386.8" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="439" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="461" fill="#0000FF" font-size="15">let</text>
+    <text x="120.2" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="461" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="461" fill="#000000" font-size="15">=</text>
+    <text x="189.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="461" fill="#267F99" font-size="15">@async</text>
+    <text x="249.2" y="461" fill="#3B3B3B" font-size="15">.</text>
+    <text x="257.8" y="461" fill="#267F99" font-size="15">Mutex</text>
+    <text x="300.8" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="309.4" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="483" fill="#AF00DB" font-size="15">for</text>
+    <text x="120.2" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="483" fill="#001080" font-size="15">i</text>
+    <text x="137.4" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="483" fill="#AF00DB" font-size="15">in</text>
+    <text x="163.2" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="483" fill="#098658" font-size="15">0</text>
+    <text x="180.4" y="483" fill="#3B3B3B" font-size="15">.</text>
+    <text x="189.0" y="483" fill="#000000" font-size="15">.&lt;</text>
+    <text x="206.2" y="483" fill="#098658" font-size="15">3</text>
+    <text x="214.8" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="483" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="505" fill="#001080" font-size="15">group</text>
+    <text x="154.6" y="505" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="505" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="232.0" y="505" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="505" fill="#3B3B3B" font-size="15">)</text>
+    <text x="249.2" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="505" fill="#000000" font-size="15">&lt;|</text>
+    <text x="275.0" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="505" fill="#3B3B3B" font-size="15">(</text>
+    <text x="292.2" y="505" fill="#3B3B3B" font-size="15">)</text>
+    <text x="300.8" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="505" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="326.6" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="335.2" y="505" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="60.0" y="527" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="527" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="527" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="527" fill="#795E26" font-size="15">acquire</text>
+    <text x="240.6" y="527" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="527" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="549" fill="#6E7681" font-size="15">24</text>
+    <text x="60.0" y="549" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="549" fill="#001080" font-size="15">log</text>
+    <text x="154.6" y="549" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="549" fill="#795E26" font-size="15">push</text>
+    <text x="197.6" y="549" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="549" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="549" fill="#A31515" font-size="15">task </text>
+    <text x="257.8" y="549" fill="#A31515" font-size="15">\{</text>
+    <text x="275.0" y="549" fill="#001080" font-size="15">i</text>
+    <text x="283.6" y="549" fill="#A31515" font-size="15">}</text>
+    <text x="292.2" y="549" fill="#A31515" font-size="15"> acquired mutex</text>
+    <text x="421.2" y="549" fill="#A31515" font-size="15">&quot;</text>
+    <text x="429.8" y="549" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="571" fill="#6E7681" font-size="15">25</text>
+    <text x="60.0" y="571" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="571" fill="#267F99" font-size="15">@async</text>
+    <text x="180.4" y="571" fill="#3B3B3B" font-size="15">.</text>
+    <text x="189.0" y="571" fill="#795E26" font-size="15">sleep</text>
+    <text x="232.0" y="571" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="571" fill="#098658" font-size="15">300</text>
+    <text x="266.4" y="571" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="593" fill="#6E7681" font-size="15">26</text>
+    <text x="60.0" y="593" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="593" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="593" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="593" fill="#795E26" font-size="15">release</text>
+    <text x="240.6" y="593" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="593" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="615" fill="#6E7681" font-size="15">27</text>
+    <text x="60.0" y="615" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="615" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="637" fill="#6E7681" font-size="15">28</text>
+    <text x="60.0" y="637" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="637" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="659" fill="#6E7681" font-size="15">29</text>
+    <text x="60.0" y="659" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="659" fill="#267F99" font-size="15">@async</text>
+    <text x="146.0" y="659" fill="#3B3B3B" font-size="15">.</text>
+    <text x="154.6" y="659" fill="#795E26" font-size="15">sleep</text>
+    <text x="197.6" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="659" fill="#098658" font-size="15">150</text>
+    <text x="232.0" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="681" fill="#6E7681" font-size="15">30</text>
+    <text x="60.0" y="681" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="681" fill="#AF00DB" font-size="15">for</text>
+    <text x="120.2" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="681" fill="#0000FF" font-size="15">_</text>
+    <text x="137.4" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="681" fill="#AF00DB" font-size="15">in</text>
+    <text x="163.2" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="681" fill="#098658" font-size="15">0</text>
+    <text x="180.4" y="681" fill="#3B3B3B" font-size="15">.</text>
+    <text x="189.0" y="681" fill="#000000" font-size="15">.&lt;</text>
+    <text x="206.2" y="681" fill="#098658" font-size="15">3</text>
+    <text x="214.8" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="681" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="703" fill="#6E7681" font-size="15">31</text>
+    <text x="60.0" y="703" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="703" fill="#001080" font-size="15">log</text>
+    <text x="137.4" y="703" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="703" fill="#795E26" font-size="15">push</text>
+    <text x="180.4" y="703" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="703" fill="#A31515" font-size="15">&quot;</text>
+    <text x="197.6" y="703" fill="#A31515" font-size="15">tick</text>
+    <text x="232.0" y="703" fill="#A31515" font-size="15">&quot;</text>
+    <text x="240.6" y="703" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="725" fill="#6E7681" font-size="15">32</text>
+    <text x="60.0" y="725" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="725" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="725" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="725" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="725" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="725" fill="#098658" font-size="15">300</text>
+    <text x="249.2" y="725" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="747" fill="#6E7681" font-size="15">33</text>
+    <text x="60.0" y="747" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="747" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="769" fill="#6E7681" font-size="15">34</text>
+    <text x="60.0" y="769" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="769" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="791" fill="#6E7681" font-size="15">35</text>
+    <text x="60.0" y="791" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="791" fill="#795E26" font-size="15">json_inspect</text>
+    <text x="180.4" y="791" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="791" fill="#001080" font-size="15">log</text>
+    <text x="214.8" y="791" fill="#3B3B3B" font-size="15">,</text>
+    <text x="223.4" y="791" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="791" fill="#001080" font-size="15">content</text>
+    <text x="292.2" y="791" fill="#000000" font-size="15">=</text>
+    <text x="300.8" y="791" fill="#3B3B3B" font-size="15">[</text>
+    <text x="26" y="813" fill="#6E7681" font-size="15">36</text>
+    <text x="60.0" y="813" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="103.0" y="813" fill="#A31515" font-size="15">task 0 acquired mutex</text>
+    <text x="283.6" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="292.2" y="813" fill="#3B3B3B" font-size="15">,</text>
+    <text x="300.8" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="813" fill="#A31515" font-size="15">tick</text>
+    <text x="352.4" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="361.0" y="813" fill="#3B3B3B" font-size="15">,</text>
+    <text x="369.6" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="378.2" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="386.8" y="813" fill="#A31515" font-size="15">task 1 acquired mutex</text>
+    <text x="567.4" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="576.0" y="813" fill="#3B3B3B" font-size="15">,</text>
+    <text x="584.6" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="593.2" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="601.8" y="813" fill="#A31515" font-size="15">tick</text>
+    <text x="636.2" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="644.8" y="813" fill="#3B3B3B" font-size="15">,</text>
+    <text x="653.4" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="662.0" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="670.6" y="813" fill="#A31515" font-size="15">task 2 acquired mutex</text>
+    <text x="851.2" y="813" fill="#A31515" font-size="15">&quot;</text>
+    <text x="859.8" y="813" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="835" fill="#6E7681" font-size="15">37</text>
+    <text x="60.0" y="835" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="835" fill="#A31515" font-size="15">&quot;</text>
+    <text x="103.0" y="835" fill="#A31515" font-size="15">tick</text>
+    <text x="137.4" y="835" fill="#A31515" font-size="15">&quot;</text>
+    <text x="146.0" y="835" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="857" fill="#6E7681" font-size="15">38</text>
+    <text x="60.0" y="857" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="857" fill="#3B3B3B" font-size="15">]</text>
+    <text x="85.8" y="857" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="879" fill="#6E7681" font-size="15">39</text>
+    <text x="60.0" y="879" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="901" fill="#6E7681" font-size="15">40</text>
+    <text x="26" y="923" fill="#6E7681" font-size="15">41</text>
+    <text x="60.0" y="923" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="945" fill="#6E7681" font-size="15">42</text>
+    <text x="60.0" y="945" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="945" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="945" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="945" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="945" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="945" fill="#A31515" font-size="15">mutex cancellation</text>
+    <text x="318.0" y="945" fill="#A31515" font-size="15">&quot;</text>
+    <text x="326.6" y="945" fill="#3B3B3B" font-size="15"> </text>
+    <text x="335.2" y="945" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="967" fill="#6E7681" font-size="15">43</text>
+    <text x="60.0" y="967" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="967" fill="#267F99" font-size="15">@async</text>
+    <text x="128.8" y="967" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="967" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="266.4" y="967" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="967" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="967" fill="#000000" font-size="15">&lt;|</text>
+    <text x="309.4" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="967" fill="#001080" font-size="15">group</text>
+    <text x="361.0" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="369.6" y="967" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="386.8" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="967" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="989" fill="#6E7681" font-size="15">44</text>
+    <text x="60.0" y="989" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="989" fill="#0000FF" font-size="15">let</text>
+    <text x="120.2" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="989" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="989" fill="#000000" font-size="15">=</text>
+    <text x="189.0" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="989" fill="#267F99" font-size="15">@async</text>
+    <text x="249.2" y="989" fill="#3B3B3B" font-size="15">.</text>
+    <text x="257.8" y="989" fill="#267F99" font-size="15">Mutex</text>
+    <text x="300.8" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="309.4" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1011" fill="#6E7681" font-size="15">45</text>
+    <text x="60.0" y="1011" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1011" fill="#001080" font-size="15">group</text>
+    <text x="137.4" y="1011" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="1011" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="214.8" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="232.0" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="1011" fill="#000000" font-size="15">&lt;|</text>
+    <text x="257.8" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="1011" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="309.4" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="1011" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1033" fill="#6E7681" font-size="15">46</text>
+    <text x="60.0" y="1033" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1033" fill="#001080" font-size="15">mutex</text>
+    <text x="154.6" y="1033" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1033" fill="#795E26" font-size="15">acquire</text>
+    <text x="223.4" y="1033" fill="#3B3B3B" font-size="15">(</text>
+    <text x="232.0" y="1033" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1055" fill="#6E7681" font-size="15">47</text>
+    <text x="60.0" y="1055" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1055" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="1055" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="1055" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="1055" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="1055" fill="#098658" font-size="15">500</text>
+    <text x="249.2" y="1055" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1077" fill="#6E7681" font-size="15">48</text>
+    <text x="60.0" y="1077" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1077" fill="#001080" font-size="15">mutex</text>
+    <text x="154.6" y="1077" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1077" fill="#795E26" font-size="15">release</text>
+    <text x="223.4" y="1077" fill="#3B3B3B" font-size="15">(</text>
+    <text x="232.0" y="1077" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1099" fill="#6E7681" font-size="15">49</text>
+    <text x="60.0" y="1099" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1099" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1121" fill="#6E7681" font-size="15">50</text>
+    <text x="60.0" y="1121" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1121" fill="#795E26" font-size="15">debug_inspect</text>
+    <text x="206.2" y="1121" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="1143" fill="#6E7681" font-size="15">51</text>
+    <text x="60.0" y="1143" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1143" fill="#AF00DB" font-size="15">try?</text>
+    <text x="146.0" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="1143" fill="#267F99" font-size="15">@async</text>
+    <text x="206.2" y="1143" fill="#3B3B3B" font-size="15">.</text>
+    <text x="214.8" y="1143" fill="#795E26" font-size="15">with_timeout</text>
+    <text x="318.0" y="1143" fill="#3B3B3B" font-size="15">(</text>
+    <text x="326.6" y="1143" fill="#098658" font-size="15">250</text>
+    <text x="352.4" y="1143" fill="#3B3B3B" font-size="15">,</text>
+    <text x="361.0" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="369.6" y="1143" fill="#3B3B3B" font-size="15">(</text>
+    <text x="378.2" y="1143" fill="#3B3B3B" font-size="15">)</text>
+    <text x="386.8" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="1143" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="412.6" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="421.2" y="1143" fill="#001080" font-size="15">mutex</text>
+    <text x="464.2" y="1143" fill="#3B3B3B" font-size="15">.</text>
+    <text x="472.8" y="1143" fill="#795E26" font-size="15">acquire</text>
+    <text x="533.0" y="1143" fill="#3B3B3B" font-size="15">(</text>
+    <text x="541.6" y="1143" fill="#3B3B3B" font-size="15">)</text>
+    <text x="550.2" y="1143" fill="#3B3B3B" font-size="15">)</text>
+    <text x="558.8" y="1143" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="1165" fill="#6E7681" font-size="15">52</text>
+    <text x="60.0" y="1165" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1165" fill="#001080" font-size="15">content</text>
+    <text x="171.8" y="1165" fill="#000000" font-size="15">=</text>
+    <text x="180.4" y="1165" fill="#A31515" font-size="15">&quot;</text>
+    <text x="189.0" y="1165" fill="#A31515" font-size="15">Err(TimeoutError)</text>
+    <text x="335.2" y="1165" fill="#A31515" font-size="15">&quot;</text>
+    <text x="343.8" y="1165" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="1187" fill="#6E7681" font-size="15">53</text>
+    <text x="60.0" y="1187" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1187" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1209" fill="#6E7681" font-size="15">54</text>
+    <text x="60.0" y="1209" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1209" fill="#267F99" font-size="15">@async</text>
+    <text x="146.0" y="1209" fill="#3B3B3B" font-size="15">.</text>
+    <text x="154.6" y="1209" fill="#795E26" font-size="15">sleep</text>
+    <text x="197.6" y="1209" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1209" fill="#098658" font-size="15">500</text>
+    <text x="232.0" y="1209" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1231" fill="#6E7681" font-size="15">55</text>
+    <text x="60.0" y="1231" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1231" fill="#795E26" font-size="15">inspect</text>
+    <text x="154.6" y="1231" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="1231" fill="#001080" font-size="15">mutex</text>
+    <text x="206.2" y="1231" fill="#3B3B3B" font-size="15">.</text>
+    <text x="214.8" y="1231" fill="#795E26" font-size="15">try_acquire</text>
+    <text x="309.4" y="1231" fill="#3B3B3B" font-size="15">(</text>
+    <text x="318.0" y="1231" fill="#3B3B3B" font-size="15">)</text>
+    <text x="326.6" y="1231" fill="#3B3B3B" font-size="15">,</text>
+    <text x="335.2" y="1231" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="1231" fill="#001080" font-size="15">content</text>
+    <text x="404.0" y="1231" fill="#000000" font-size="15">=</text>
+    <text x="412.6" y="1231" fill="#A31515" font-size="15">&quot;</text>
+    <text x="421.2" y="1231" fill="#A31515" font-size="15">true</text>
+    <text x="455.6" y="1231" fill="#A31515" font-size="15">&quot;</text>
+    <text x="464.2" y="1231" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1253" fill="#6E7681" font-size="15">56</text>
+    <text x="60.0" y="1253" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1253" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1275" fill="#6E7681" font-size="15">57</text>
+    <text x="60.0" y="1275" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1297" fill="#6E7681" font-size="15">58</text>
+    <text x="26" y="1319" fill="#6E7681" font-size="15">59</text>
+    <text x="60.0" y="1319" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="1341" fill="#6E7681" font-size="15">60</text>
+    <text x="60.0" y="1341" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="1341" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1341" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="1341" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="1341" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="1341" fill="#A31515" font-size="15">mutex cancellation no_swallow</text>
+    <text x="412.6" y="1341" fill="#A31515" font-size="15">&quot;</text>
+    <text x="421.2" y="1341" fill="#3B3B3B" font-size="15"> </text>
+    <text x="429.8" y="1341" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1363" fill="#6E7681" font-size="15">61</text>
+    <text x="60.0" y="1363" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1363" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1363" fill="#001080" font-size="15">log</text>
+    <text x="137.4" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1363" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="1363" fill="#3B3B3B" font-size="15">[</text>
+    <text x="171.8" y="1363" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="1385" fill="#6E7681" font-size="15">62</text>
+    <text x="60.0" y="1385" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1385" fill="#267F99" font-size="15">@async</text>
+    <text x="128.8" y="1385" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="1385" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="266.4" y="1385" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="1385" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="1385" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="1385" fill="#000000" font-size="15">&lt;|</text>
+    <text x="309.4" y="1385" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="1385" fill="#001080" font-size="15">group</text>
+    <text x="361.0" y="1385" fill="#3B3B3B" font-size="15"> </text>
+    <text x="369.6" y="1385" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="386.8" y="1385" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="1385" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1407" fill="#6E7681" font-size="15">63</text>
+    <text x="60.0" y="1407" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1407" fill="#0000FF" font-size="15">let</text>
+    <text x="120.2" y="1407" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="1407" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="1407" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="1407" fill="#000000" font-size="15">=</text>
+    <text x="189.0" y="1407" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="1407" fill="#267F99" font-size="15">@async</text>
+    <text x="249.2" y="1407" fill="#3B3B3B" font-size="15">.</text>
+    <text x="257.8" y="1407" fill="#267F99" font-size="15">Mutex</text>
+    <text x="300.8" y="1407" fill="#3B3B3B" font-size="15">(</text>
+    <text x="309.4" y="1407" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1429" fill="#6E7681" font-size="15">64</text>
+    <text x="60.0" y="1429" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1429" fill="#001080" font-size="15">mutex</text>
+    <text x="137.4" y="1429" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="1429" fill="#795E26" font-size="15">acquire</text>
+    <text x="206.2" y="1429" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="1429" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1451" fill="#6E7681" font-size="15">65</text>
+    <text x="60.0" y="1451" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1451" fill="#0000FF" font-size="15">let</text>
+    <text x="120.2" y="1451" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="1451" fill="#001080" font-size="15">acquire_taskire_task</text>
+    <text x="300.8" y="1451" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="1451" fill="#000000" font-size="15">=</text>
+    <text x="318.0" y="1451" fill="#3B3B3B" font-size="15"> </text>
+    <text x="326.6" y="1451" fill="#001080" font-size="15">group</text>
+    <text x="369.6" y="1451" fill="#3B3B3B" font-size="15">.</text>
+    <text x="378.2" y="1451" fill="#795E26" font-size="15">spawn</text>
+    <text x="421.2" y="1451" fill="#3B3B3B" font-size="15">(</text>
+    <text x="429.8" y="1451" fill="#3B3B3B" font-size="15">(</text>
+    <text x="438.4" y="1451" fill="#3B3B3B" font-size="15">)</text>
+    <text x="447.0" y="1451" fill="#3B3B3B" font-size="15"> </text>
+    <text x="455.6" y="1451" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="472.8" y="1451" fill="#3B3B3B" font-size="15"> </text>
+    <text x="481.4" y="1451" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1473" fill="#6E7681" font-size="15">66</text>
+    <text x="60.0" y="1473" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1473" fill="#001080" font-size="15">mutex</text>
+    <text x="154.6" y="1473" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1473" fill="#795E26" font-size="15">acquire</text>
+    <text x="223.4" y="1473" fill="#3B3B3B" font-size="15">(</text>
+    <text x="232.0" y="1473" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1495" fill="#6E7681" font-size="15">67</text>
+    <text x="60.0" y="1495" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1495" fill="#001080" font-size="15">log</text>
+    <text x="137.4" y="1495" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="1495" fill="#795E26" font-size="15">push</text>
+    <text x="180.4" y="1495" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="1495" fill="#A31515" font-size="15">&quot;</text>
+    <text x="197.6" y="1495" fill="#A31515" font-size="15">acquire() succeed</text>
+    <text x="343.8" y="1495" fill="#A31515" font-size="15">&quot;</text>
+    <text x="352.4" y="1495" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1517" fill="#6E7681" font-size="15">68</text>
+    <text x="60.0" y="1517" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1517" fill="#3B3B3B" font-size="15">}</text>
+    <text x="103.0" y="1517" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1539" fill="#6E7681" font-size="15">69</text>
+    <text x="60.0" y="1539" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1539" fill="#267F99" font-size="15">@async</text>
+    <text x="146.0" y="1539" fill="#3B3B3B" font-size="15">.</text>
+    <text x="154.6" y="1539" fill="#795E26" font-size="15">sleep</text>
+    <text x="197.6" y="1539" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1539" fill="#098658" font-size="15">100</text>
+    <text x="232.0" y="1539" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1561" fill="#6E7681" font-size="15">70</text>
+    <text x="60.0" y="1561" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1561" fill="#001080" font-size="15">mutex</text>
+    <text x="137.4" y="1561" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="1561" fill="#795E26" font-size="15">release</text>
+    <text x="206.2" y="1561" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="1561" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1583" fill="#6E7681" font-size="15">71</text>
+    <text x="60.0" y="1583" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1583" fill="#001080" font-size="15">acquire_taskire_task</text>
+    <text x="266.4" y="1583" fill="#3B3B3B" font-size="15">.</text>
+    <text x="275.0" y="1583" fill="#795E26" font-size="15">cancel</text>
+    <text x="326.6" y="1583" fill="#3B3B3B" font-size="15">(</text>
+    <text x="335.2" y="1583" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1605" fill="#6E7681" font-size="15">72</text>
+    <text x="60.0" y="1605" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1605" fill="#267F99" font-size="15">@async</text>
+    <text x="146.0" y="1605" fill="#3B3B3B" font-size="15">.</text>
+    <text x="154.6" y="1605" fill="#795E26" font-size="15">sleep</text>
+    <text x="197.6" y="1605" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1605" fill="#098658" font-size="15">100</text>
+    <text x="232.0" y="1605" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1627" fill="#6E7681" font-size="15">73</text>
+    <text x="60.0" y="1627" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1627" fill="#795E26" font-size="15">inspect</text>
+    <text x="154.6" y="1627" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="1627" fill="#001080" font-size="15">mutex</text>
+    <text x="206.2" y="1627" fill="#3B3B3B" font-size="15">.</text>
+    <text x="214.8" y="1627" fill="#795E26" font-size="15">try_acquire</text>
+    <text x="309.4" y="1627" fill="#3B3B3B" font-size="15">(</text>
+    <text x="318.0" y="1627" fill="#3B3B3B" font-size="15">)</text>
+    <text x="326.6" y="1627" fill="#3B3B3B" font-size="15">,</text>
+    <text x="335.2" y="1627" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="1627" fill="#001080" font-size="15">content</text>
+    <text x="404.0" y="1627" fill="#000000" font-size="15">=</text>
+    <text x="412.6" y="1627" fill="#A31515" font-size="15">&quot;</text>
+    <text x="421.2" y="1627" fill="#A31515" font-size="15">false</text>
+    <text x="464.2" y="1627" fill="#A31515" font-size="15">&quot;</text>
+    <text x="472.8" y="1627" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1649" fill="#6E7681" font-size="15">74</text>
+    <text x="60.0" y="1649" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1649" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1671" fill="#6E7681" font-size="15">75</text>
+    <text x="60.0" y="1671" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1671" fill="#795E26" font-size="15">json_inspect</text>
+    <text x="180.4" y="1671" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="1671" fill="#001080" font-size="15">log</text>
+    <text x="214.8" y="1671" fill="#3B3B3B" font-size="15">,</text>
+    <text x="223.4" y="1671" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="1671" fill="#001080" font-size="15">content</text>
+    <text x="292.2" y="1671" fill="#000000" font-size="15">=</text>
+    <text x="300.8" y="1671" fill="#3B3B3B" font-size="15">[</text>
+    <text x="309.4" y="1671" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="1671" fill="#A31515" font-size="15">acquire() succeed</text>
+    <text x="464.2" y="1671" fill="#A31515" font-size="15">&quot;</text>
+    <text x="472.8" y="1671" fill="#3B3B3B" font-size="15">]</text>
+    <text x="481.4" y="1671" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1693" fill="#6E7681" font-size="15">76</text>
+    <text x="60.0" y="1693" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1715" fill="#6E7681" font-size="15">77</text>
+    <text x="26" y="1737" fill="#6E7681" font-size="15">78</text>
+    <text x="60.0" y="1737" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="1759" fill="#6E7681" font-size="15">79</text>
+    <text x="60.0" y="1759" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="1759" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1759" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="1759" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="1759" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="1759" fill="#A31515" font-size="15">mutex fairness</text>
+    <text x="283.6" y="1759" fill="#A31515" font-size="15">&quot;</text>
+    <text x="292.2" y="1759" fill="#3B3B3B" font-size="15"> </text>
+    <text x="300.8" y="1759" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1781" fill="#6E7681" font-size="15">80</text>
+    <text x="60.0" y="1781" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1781" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="1781" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1781" fill="#001080" font-size="15">log</text>
+    <text x="137.4" y="1781" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1781" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="1781" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="1781" fill="#3B3B3B" font-size="15">[</text>
+    <text x="171.8" y="1781" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="1803" fill="#6E7681" font-size="15">81</text>
+    <text x="60.0" y="1803" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1803" fill="#267F99" font-size="15">@async</text>
+    <text x="128.8" y="1803" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="1803" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="266.4" y="1803" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="1803" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="1803" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="1803" fill="#000000" font-size="15">&lt;|</text>
+    <text x="309.4" y="1803" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="1803" fill="#001080" font-size="15">group</text>
+    <text x="361.0" y="1803" fill="#3B3B3B" font-size="15"> </text>
+    <text x="369.6" y="1803" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="386.8" y="1803" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="1803" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1825" fill="#6E7681" font-size="15">82</text>
+    <text x="60.0" y="1825" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1825" fill="#0000FF" font-size="15">let</text>
+    <text x="120.2" y="1825" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="1825" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="1825" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="1825" fill="#000000" font-size="15">=</text>
+    <text x="189.0" y="1825" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="1825" fill="#267F99" font-size="15">@async</text>
+    <text x="249.2" y="1825" fill="#3B3B3B" font-size="15">.</text>
+    <text x="257.8" y="1825" fill="#267F99" font-size="15">Mutex</text>
+    <text x="300.8" y="1825" fill="#3B3B3B" font-size="15">(</text>
+    <text x="309.4" y="1825" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1847" fill="#6E7681" font-size="15">83</text>
+    <text x="60.0" y="1847" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1847" fill="#001080" font-size="15">group</text>
+    <text x="137.4" y="1847" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="1847" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="214.8" y="1847" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="1847" fill="#3B3B3B" font-size="15">)</text>
+    <text x="232.0" y="1847" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="1847" fill="#000000" font-size="15">&lt;|</text>
+    <text x="257.8" y="1847" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="1847" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="1847" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="1847" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="1847" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="309.4" y="1847" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="1847" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1869" fill="#6E7681" font-size="15">84</text>
+    <text x="60.0" y="1869" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1869" fill="#AF00DB" font-size="15">for</text>
+    <text x="137.4" y="1869" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1869" fill="#0000FF" font-size="15">_</text>
+    <text x="154.6" y="1869" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="1869" fill="#AF00DB" font-size="15">in</text>
+    <text x="180.4" y="1869" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="1869" fill="#098658" font-size="15">0</text>
+    <text x="197.6" y="1869" fill="#3B3B3B" font-size="15">.</text>
+    <text x="206.2" y="1869" fill="#000000" font-size="15">.&lt;</text>
+    <text x="223.4" y="1869" fill="#098658" font-size="15">3</text>
+    <text x="232.0" y="1869" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="1869" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1891" fill="#6E7681" font-size="15">85</text>
+    <text x="60.0" y="1891" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1891" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="1891" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="1891" fill="#795E26" font-size="15">acquire</text>
+    <text x="240.6" y="1891" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="1891" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1913" fill="#6E7681" font-size="15">86</text>
+    <text x="60.0" y="1913" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1913" fill="#001080" font-size="15">log</text>
+    <text x="154.6" y="1913" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1913" fill="#795E26" font-size="15">push</text>
+    <text x="197.6" y="1913" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1913" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="1913" fill="#A31515" font-size="15">task 1 acquired mutex</text>
+    <text x="395.4" y="1913" fill="#A31515" font-size="15">&quot;</text>
+    <text x="404.0" y="1913" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1935" fill="#6E7681" font-size="15">87</text>
+    <text x="60.0" y="1935" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1935" fill="#267F99" font-size="15">@async</text>
+    <text x="180.4" y="1935" fill="#3B3B3B" font-size="15">.</text>
+    <text x="189.0" y="1935" fill="#795E26" font-size="15">sleep</text>
+    <text x="232.0" y="1935" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="1935" fill="#098658" font-size="15">200</text>
+    <text x="266.4" y="1935" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1957" fill="#6E7681" font-size="15">88</text>
+    <text x="60.0" y="1957" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1957" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="1957" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="1957" fill="#795E26" font-size="15">release</text>
+    <text x="240.6" y="1957" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="1957" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1979" fill="#6E7681" font-size="15">89</text>
+    <text x="60.0" y="1979" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1979" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="2001" fill="#6E7681" font-size="15">90</text>
+    <text x="60.0" y="2001" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="2001" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="2023" fill="#6E7681" font-size="15">91</text>
+    <text x="60.0" y="2023" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="2023" fill="#001080" font-size="15">group</text>
+    <text x="137.4" y="2023" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="2023" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="214.8" y="2023" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="2023" fill="#3B3B3B" font-size="15">)</text>
+    <text x="232.0" y="2023" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="2023" fill="#000000" font-size="15">&lt;|</text>
+    <text x="257.8" y="2023" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="2023" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="2023" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="2023" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="2023" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="309.4" y="2023" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="2023" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="2045" fill="#6E7681" font-size="15">92</text>
+    <text x="60.0" y="2045" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="2045" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="2045" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="2045" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="2045" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="2045" fill="#098658" font-size="15">100</text>
+    <text x="249.2" y="2045" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="2067" fill="#6E7681" font-size="15">93</text>
+    <text x="60.0" y="2067" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="2067" fill="#AF00DB" font-size="15">for</text>
+    <text x="137.4" y="2067" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="2067" fill="#0000FF" font-size="15">_</text>
+    <text x="154.6" y="2067" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="2067" fill="#AF00DB" font-size="15">in</text>
+    <text x="180.4" y="2067" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="2067" fill="#098658" font-size="15">0</text>
+    <text x="197.6" y="2067" fill="#3B3B3B" font-size="15">.</text>
+    <text x="206.2" y="2067" fill="#000000" font-size="15">.&lt;</text>
+    <text x="223.4" y="2067" fill="#098658" font-size="15">3</text>
+    <text x="232.0" y="2067" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="2067" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="2089" fill="#6E7681" font-size="15">94</text>
+    <text x="60.0" y="2089" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="2089" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="2089" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="2089" fill="#795E26" font-size="15">acquire</text>
+    <text x="240.6" y="2089" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="2089" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="2111" fill="#6E7681" font-size="15">95</text>
+    <text x="60.0" y="2111" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="2111" fill="#001080" font-size="15">log</text>
+    <text x="154.6" y="2111" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="2111" fill="#795E26" font-size="15">push</text>
+    <text x="197.6" y="2111" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="2111" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="2111" fill="#A31515" font-size="15">task 2 acquired mutex</text>
+    <text x="395.4" y="2111" fill="#A31515" font-size="15">&quot;</text>
+    <text x="404.0" y="2111" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="2133" fill="#6E7681" font-size="15">96</text>
+    <text x="60.0" y="2133" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="2133" fill="#267F99" font-size="15">@async</text>
+    <text x="180.4" y="2133" fill="#3B3B3B" font-size="15">.</text>
+    <text x="189.0" y="2133" fill="#795E26" font-size="15">sleep</text>
+    <text x="232.0" y="2133" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="2133" fill="#098658" font-size="15">200</text>
+    <text x="266.4" y="2133" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="2155" fill="#6E7681" font-size="15">97</text>
+    <text x="60.0" y="2155" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="2155" fill="#001080" font-size="15">mutex</text>
+    <text x="171.8" y="2155" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="2155" fill="#795E26" font-size="15">release</text>
+    <text x="240.6" y="2155" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="2155" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="2177" fill="#6E7681" font-size="15">98</text>
+    <text x="60.0" y="2177" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="2177" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="2199" fill="#6E7681" font-size="15">99</text>
+    <text x="60.0" y="2199" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="2199" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="2221" fill="#6E7681" font-size="15">100</text>
+    <text x="60.0" y="2221" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="2221" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="2243" fill="#6E7681" font-size="15">101</text>
+    <text x="60.0" y="2243" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="2243" fill="#795E26" font-size="15">json_inspect</text>
+    <text x="180.4" y="2243" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="2243" fill="#001080" font-size="15">log</text>
+    <text x="214.8" y="2243" fill="#3B3B3B" font-size="15">,</text>
+    <text x="223.4" y="2243" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="2243" fill="#001080" font-size="15">content</text>
+    <text x="292.2" y="2243" fill="#000000" font-size="15">=</text>
+    <text x="300.8" y="2243" fill="#3B3B3B" font-size="15">[</text>
+    <text x="26" y="2265" fill="#6E7681" font-size="15">102</text>
+    <text x="60.0" y="2265" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="103.0" y="2265" fill="#A31515" font-size="15">task 1 acquired mutex</text>
+    <text x="283.6" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="292.2" y="2265" fill="#3B3B3B" font-size="15">,</text>
+    <text x="300.8" y="2265" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="2265" fill="#A31515" font-size="15">task 2 acquired mutex</text>
+    <text x="498.6" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="507.2" y="2265" fill="#3B3B3B" font-size="15">,</text>
+    <text x="515.8" y="2265" fill="#3B3B3B" font-size="15"> </text>
+    <text x="524.4" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="533.0" y="2265" fill="#A31515" font-size="15">task 1 acquired mutex</text>
+    <text x="713.6" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="722.2" y="2265" fill="#3B3B3B" font-size="15">,</text>
+    <text x="730.8" y="2265" fill="#3B3B3B" font-size="15"> </text>
+    <text x="739.4" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="748.0" y="2265" fill="#A31515" font-size="15">task 2 acquired mutex</text>
+    <text x="928.6" y="2265" fill="#A31515" font-size="15">&quot;</text>
+    <text x="937.2" y="2265" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="2287" fill="#6E7681" font-size="15">103</text>
+    <text x="60.0" y="2287" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="2287" fill="#A31515" font-size="15">&quot;</text>
+    <text x="103.0" y="2287" fill="#A31515" font-size="15">task 1 acquired mutex</text>
+    <text x="283.6" y="2287" fill="#A31515" font-size="15">&quot;</text>
+    <text x="292.2" y="2287" fill="#3B3B3B" font-size="15">,</text>
+    <text x="300.8" y="2287" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="2287" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="2287" fill="#A31515" font-size="15">task 2 acquired mutex</text>
+    <text x="498.6" y="2287" fill="#A31515" font-size="15">&quot;</text>
+    <text x="507.2" y="2287" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="2309" fill="#6E7681" font-size="15">104</text>
+    <text x="60.0" y="2309" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="2309" fill="#3B3B3B" font-size="15">]</text>
+    <text x="85.8" y="2309" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="2331" fill="#6E7681" font-size="15">105</text>
+    <text x="60.0" y="2331" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/async-semaphore.svg
+++ b/artifacts/previews/async-semaphore.svg
@@ -102,7 +102,7 @@
     <text x="85.8" y="461" fill="#3B3B3B" font-size="15"> </text>
     <text x="94.4" y="461" fill="#0000FF" font-size="15">fn</text>
     <text x="111.6" y="461" fill="#3B3B3B" font-size="15"> </text>
-    <text x="120.2" y="461" fill="#795E26" font-size="15">Semaphore</text>
+    <text x="120.2" y="461" fill="#267F99" font-size="15">Semaphore</text>
     <text x="197.6" y="461" fill="#3B3B3B" font-size="15">:</text>
     <text x="206.2" y="461" fill="#3B3B3B" font-size="15">:</text>
     <text x="214.8" y="461" fill="#267F99" font-size="15">Semaphore</text>
@@ -188,7 +188,7 @@
     <text x="85.8" y="681" fill="#3B3B3B" font-size="15"> </text>
     <text x="94.4" y="681" fill="#0000FF" font-size="15">fn</text>
     <text x="111.6" y="681" fill="#3B3B3B" font-size="15"> </text>
-    <text x="120.2" y="681" fill="#795E26" font-size="15">Semaphore</text>
+    <text x="120.2" y="681" fill="#267F99" font-size="15">Semaphore</text>
     <text x="197.6" y="681" fill="#3B3B3B" font-size="15">:</text>
     <text x="206.2" y="681" fill="#3B3B3B" font-size="15">:</text>
     <text x="214.8" y="681" fill="#795E26" font-size="15">release</text>
@@ -322,7 +322,7 @@
     <text x="137.4" y="1055" fill="#3B3B3B" font-size="15"> </text>
     <text x="146.0" y="1055" fill="#0000FF" font-size="15">fn</text>
     <text x="163.2" y="1055" fill="#3B3B3B" font-size="15"> </text>
-    <text x="171.8" y="1055" fill="#795E26" font-size="15">Semaphore</text>
+    <text x="171.8" y="1055" fill="#267F99" font-size="15">Semaphore</text>
     <text x="249.2" y="1055" fill="#3B3B3B" font-size="15">:</text>
     <text x="257.8" y="1055" fill="#3B3B3B" font-size="15">:</text>
     <text x="266.4" y="1055" fill="#795E26" font-size="15">acquire</text>

--- a/artifacts/previews/async-spawn-test.svg
+++ b/artifacts/previews/async-spawn-test.svg
@@ -1,0 +1,537 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="774" height="1618" viewBox="0 0 774 1618">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#008000" font-size="15">// Source: /Users/baozhiyuan/Workspace/async/src/spawn_test.mbt</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#008000" font-size="15">// Copyright 2025 International Digital Economy Academy</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#008000" font-size="15">//</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#008000" font-size="15">// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#008000" font-size="15">// you may not use this file except in compliance with the License.</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#008000" font-size="15">// You may obtain a copy of the License at</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#008000" font-size="15">//</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#008000" font-size="15">//     http://www.apache.org/licenses/LICENSE-2.0</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#008000" font-size="15">//</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#008000" font-size="15">// Unless required by applicable law or agreed to in writing, software</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#008000" font-size="15">// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#008000" font-size="15">// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#008000" font-size="15">// See the License for the specific language governing permissions and</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#008000" font-size="15">// limitations under the License.</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="395" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="395" fill="#A31515" font-size="15">spawn error1</text>
+    <text x="266.4" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="275.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="395" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="417" fill="#001080" font-size="15">buf</text>
+    <text x="137.4" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="417" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="417" fill="#267F99" font-size="15">StringBuilder</text>
+    <text x="275.0" y="417" fill="#3B3B3B" font-size="15">:</text>
+    <text x="283.6" y="417" fill="#3B3B3B" font-size="15">:</text>
+    <text x="292.2" y="417" fill="#795E26" font-size="15">new</text>
+    <text x="318.0" y="417" fill="#3B3B3B" font-size="15">(</text>
+    <text x="326.6" y="417" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="439" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="439" fill="#001080" font-size="15">result</text>
+    <text x="163.2" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="439" fill="#000000" font-size="15">=</text>
+    <text x="180.4" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="439" fill="#AF00DB" font-size="15">try?</text>
+    <text x="223.4" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="439" fill="#267F99" font-size="15">@async</text>
+    <text x="283.6" y="439" fill="#3B3B3B" font-size="15">.</text>
+    <text x="292.2" y="439" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="421.2" y="439" fill="#3B3B3B" font-size="15">(</text>
+    <text x="429.8" y="439" fill="#001080" font-size="15">root</text>
+    <text x="464.2" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="472.8" y="439" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="490.0" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="498.6" y="439" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="461" fill="#001080" font-size="15">root</text>
+    <text x="128.8" y="461" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="461" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="206.2" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="461" fill="#000000" font-size="15">&lt;|</text>
+    <text x="249.2" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="275.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="461" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="300.8" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="461" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="483" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="483" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="483" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="483" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="483" fill="#098658" font-size="15">1000</text>
+    <text x="257.8" y="483" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="505" fill="#001080" font-size="15">buf</text>
+    <text x="137.4" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="505" fill="#000000" font-size="15">&lt;</text>
+    <text x="154.6" y="505" fill="#000000" font-size="15">+</text>
+    <text x="163.2" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="505" fill="#A31515" font-size="15">&quot;</text>
+    <text x="180.4" y="505" fill="#A31515" font-size="15">task 1 finished</text>
+    <text x="309.4" y="505" fill="#EE0000" font-size="15">\n</text>
+    <text x="326.6" y="505" fill="#A31515" font-size="15">&quot;</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="60.0" y="527" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="527" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="549" fill="#6E7681" font-size="15">24</text>
+    <text x="60.0" y="549" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="549" fill="#001080" font-size="15">root</text>
+    <text x="128.8" y="549" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="549" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="206.2" y="549" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="549" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="549" fill="#000000" font-size="15">&lt;|</text>
+    <text x="249.2" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="549" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="549" fill="#3B3B3B" font-size="15">)</text>
+    <text x="275.0" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="549" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="300.8" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="549" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="571" fill="#6E7681" font-size="15">25</text>
+    <text x="60.0" y="571" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="571" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="571" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="571" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="571" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="571" fill="#098658" font-size="15">200</text>
+    <text x="249.2" y="571" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="593" fill="#6E7681" font-size="15">26</text>
+    <text x="60.0" y="593" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="593" fill="#AF00DB" font-size="15">raise</text>
+    <text x="154.6" y="593" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="593" fill="#267F99" font-size="15">Err</text>
+    <text x="26" y="615" fill="#6E7681" font-size="15">27</text>
+    <text x="60.0" y="615" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="615" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="637" fill="#6E7681" font-size="15">28</text>
+    <text x="60.0" y="637" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="637" fill="#3B3B3B" font-size="15">}</text>
+    <text x="85.8" y="637" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="659" fill="#6E7681" font-size="15">29</text>
+    <text x="60.0" y="659" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="659" fill="#001080" font-size="15">buf</text>
+    <text x="103.0" y="659" fill="#3B3B3B" font-size="15">.</text>
+    <text x="111.6" y="659" fill="#795E26" font-size="15">write_string</text>
+    <text x="214.8" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="659" fill="#267F99" font-size="15">@debug</text>
+    <text x="275.0" y="659" fill="#3B3B3B" font-size="15">.</text>
+    <text x="283.6" y="659" fill="#795E26" font-size="15">to_string</text>
+    <text x="361.0" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="369.6" y="659" fill="#001080" font-size="15">result</text>
+    <text x="421.2" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="429.8" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="681" fill="#6E7681" font-size="15">30</text>
+    <text x="60.0" y="681" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="681" fill="#795E26" font-size="15">inspect</text>
+    <text x="137.4" y="681" fill="#3B3B3B" font-size="15">(</text>
+    <text x="146.0" y="681" fill="#001080" font-size="15">buf</text>
+    <text x="171.8" y="681" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="681" fill="#795E26" font-size="15">to_string</text>
+    <text x="257.8" y="681" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="681" fill="#3B3B3B" font-size="15">)</text>
+    <text x="275.0" y="681" fill="#3B3B3B" font-size="15">,</text>
+    <text x="283.6" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="681" fill="#001080" font-size="15">content</text>
+    <text x="352.4" y="681" fill="#000000" font-size="15">=</text>
+    <text x="361.0" y="681" fill="#A31515" font-size="15">&quot;</text>
+    <text x="369.6" y="681" fill="#A31515" font-size="15">Err(Err)</text>
+    <text x="438.4" y="681" fill="#A31515" font-size="15">&quot;</text>
+    <text x="447.0" y="681" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="703" fill="#6E7681" font-size="15">31</text>
+    <text x="60.0" y="703" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="725" fill="#6E7681" font-size="15">32</text>
+    <text x="26" y="747" fill="#6E7681" font-size="15">33</text>
+    <text x="60.0" y="747" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="769" fill="#6E7681" font-size="15">34</text>
+    <text x="60.0" y="769" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="769" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="769" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="769" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="769" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="769" fill="#A31515" font-size="15">spawn error2</text>
+    <text x="266.4" y="769" fill="#A31515" font-size="15">&quot;</text>
+    <text x="275.0" y="769" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="769" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="791" fill="#6E7681" font-size="15">35</text>
+    <text x="60.0" y="791" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="791" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="791" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="791" fill="#001080" font-size="15">buf</text>
+    <text x="137.4" y="791" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="791" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="791" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="791" fill="#267F99" font-size="15">StringBuilder</text>
+    <text x="275.0" y="791" fill="#3B3B3B" font-size="15">:</text>
+    <text x="283.6" y="791" fill="#3B3B3B" font-size="15">:</text>
+    <text x="292.2" y="791" fill="#795E26" font-size="15">new</text>
+    <text x="318.0" y="791" fill="#3B3B3B" font-size="15">(</text>
+    <text x="326.6" y="791" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="813" fill="#6E7681" font-size="15">36</text>
+    <text x="60.0" y="813" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="813" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="813" fill="#001080" font-size="15">result</text>
+    <text x="163.2" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="813" fill="#000000" font-size="15">=</text>
+    <text x="180.4" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="813" fill="#AF00DB" font-size="15">try?</text>
+    <text x="223.4" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="813" fill="#267F99" font-size="15">@async</text>
+    <text x="283.6" y="813" fill="#3B3B3B" font-size="15">.</text>
+    <text x="292.2" y="813" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="421.2" y="813" fill="#3B3B3B" font-size="15">(</text>
+    <text x="429.8" y="813" fill="#001080" font-size="15">root</text>
+    <text x="464.2" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="472.8" y="813" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="490.0" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="498.6" y="813" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="835" fill="#6E7681" font-size="15">37</text>
+    <text x="60.0" y="835" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="835" fill="#001080" font-size="15">root</text>
+    <text x="128.8" y="835" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="835" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="206.2" y="835" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="835" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="835" fill="#000000" font-size="15">&lt;|</text>
+    <text x="249.2" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="835" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="835" fill="#3B3B3B" font-size="15">)</text>
+    <text x="275.0" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="835" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="300.8" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="835" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="857" fill="#6E7681" font-size="15">38</text>
+    <text x="60.0" y="857" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="857" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="857" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="857" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="857" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="857" fill="#098658" font-size="15">200</text>
+    <text x="249.2" y="857" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="879" fill="#6E7681" font-size="15">39</text>
+    <text x="60.0" y="879" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="879" fill="#AF00DB" font-size="15">raise</text>
+    <text x="154.6" y="879" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="879" fill="#267F99" font-size="15">Err</text>
+    <text x="26" y="901" fill="#6E7681" font-size="15">40</text>
+    <text x="60.0" y="901" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="901" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="923" fill="#6E7681" font-size="15">41</text>
+    <text x="60.0" y="923" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="923" fill="#001080" font-size="15">root</text>
+    <text x="128.8" y="923" fill="#3B3B3B" font-size="15">.</text>
+    <text x="137.4" y="923" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="206.2" y="923" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="923" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="923" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="923" fill="#000000" font-size="15">&lt;|</text>
+    <text x="249.2" y="923" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="923" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="923" fill="#3B3B3B" font-size="15">)</text>
+    <text x="275.0" y="923" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="923" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="300.8" y="923" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="923" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="945" fill="#6E7681" font-size="15">42</text>
+    <text x="60.0" y="945" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="945" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="945" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="945" fill="#795E26" font-size="15">sleep</text>
+    <text x="214.8" y="945" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="945" fill="#098658" font-size="15">1000</text>
+    <text x="257.8" y="945" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="967" fill="#6E7681" font-size="15">43</text>
+    <text x="60.0" y="967" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="967" fill="#001080" font-size="15">buf</text>
+    <text x="137.4" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="967" fill="#000000" font-size="15">&lt;</text>
+    <text x="154.6" y="967" fill="#000000" font-size="15">+</text>
+    <text x="163.2" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="967" fill="#A31515" font-size="15">&quot;</text>
+    <text x="180.4" y="967" fill="#A31515" font-size="15">task 1 finished</text>
+    <text x="309.4" y="967" fill="#EE0000" font-size="15">\n</text>
+    <text x="326.6" y="967" fill="#A31515" font-size="15">&quot;</text>
+    <text x="26" y="989" fill="#6E7681" font-size="15">44</text>
+    <text x="60.0" y="989" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="989" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1011" fill="#6E7681" font-size="15">45</text>
+    <text x="60.0" y="1011" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1011" fill="#3B3B3B" font-size="15">}</text>
+    <text x="85.8" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1033" fill="#6E7681" font-size="15">46</text>
+    <text x="60.0" y="1033" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1033" fill="#001080" font-size="15">buf</text>
+    <text x="103.0" y="1033" fill="#3B3B3B" font-size="15">.</text>
+    <text x="111.6" y="1033" fill="#795E26" font-size="15">write_string</text>
+    <text x="214.8" y="1033" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="1033" fill="#267F99" font-size="15">@debug</text>
+    <text x="275.0" y="1033" fill="#3B3B3B" font-size="15">.</text>
+    <text x="283.6" y="1033" fill="#795E26" font-size="15">to_string</text>
+    <text x="361.0" y="1033" fill="#3B3B3B" font-size="15">(</text>
+    <text x="369.6" y="1033" fill="#001080" font-size="15">result</text>
+    <text x="421.2" y="1033" fill="#3B3B3B" font-size="15">)</text>
+    <text x="429.8" y="1033" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1055" fill="#6E7681" font-size="15">47</text>
+    <text x="60.0" y="1055" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1055" fill="#795E26" font-size="15">inspect</text>
+    <text x="137.4" y="1055" fill="#3B3B3B" font-size="15">(</text>
+    <text x="146.0" y="1055" fill="#001080" font-size="15">buf</text>
+    <text x="171.8" y="1055" fill="#3B3B3B" font-size="15">.</text>
+    <text x="180.4" y="1055" fill="#795E26" font-size="15">to_string</text>
+    <text x="257.8" y="1055" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="1055" fill="#3B3B3B" font-size="15">)</text>
+    <text x="275.0" y="1055" fill="#3B3B3B" font-size="15">,</text>
+    <text x="283.6" y="1055" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="1055" fill="#001080" font-size="15">content</text>
+    <text x="352.4" y="1055" fill="#000000" font-size="15">=</text>
+    <text x="361.0" y="1055" fill="#A31515" font-size="15">&quot;</text>
+    <text x="369.6" y="1055" fill="#A31515" font-size="15">Err(Err)</text>
+    <text x="438.4" y="1055" fill="#A31515" font-size="15">&quot;</text>
+    <text x="447.0" y="1055" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1077" fill="#6E7681" font-size="15">48</text>
+    <text x="60.0" y="1077" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1099" fill="#6E7681" font-size="15">49</text>
+    <text x="26" y="1121" fill="#6E7681" font-size="15">50</text>
+    <text x="60.0" y="1121" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="1143" fill="#6E7681" font-size="15">51</text>
+    <text x="60.0" y="1143" fill="#0000FF" font-size="15">async</text>
+    <text x="103.0" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1143" fill="#0000FF" font-size="15">test</text>
+    <text x="146.0" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="1143" fill="#A31515" font-size="15">&quot;</text>
+    <text x="163.2" y="1143" fill="#A31515" font-size="15">spawn after cancelled</text>
+    <text x="343.8" y="1143" fill="#A31515" font-size="15">&quot;</text>
+    <text x="352.4" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="361.0" y="1143" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1165" fill="#6E7681" font-size="15">52</text>
+    <text x="60.0" y="1165" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1165" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="1165" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1165" fill="#001080" font-size="15">log</text>
+    <text x="137.4" y="1165" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1165" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="1165" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="1165" fill="#3B3B3B" font-size="15">[</text>
+    <text x="171.8" y="1165" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="1187" fill="#6E7681" font-size="15">53</text>
+    <text x="60.0" y="1187" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1187" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1187" fill="#001080" font-size="15">_</text>
+    <text x="120.2" y="1187" fill="#000000" font-size="15"> :</text>
+    <text x="137.4" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1187" fill="#267F99" font-size="15">Result</text>
+    <text x="197.6" y="1187" fill="#3B3B3B" font-size="15">[</text>
+    <text x="206.2" y="1187" fill="#267F99" font-size="15">Unit</text>
+    <text x="240.6" y="1187" fill="#3B3B3B" font-size="15">,</text>
+    <text x="249.2" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="1187" fill="#0000FF" font-size="15">_</text>
+    <text x="266.4" y="1187" fill="#3B3B3B" font-size="15">]</text>
+    <text x="275.0" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="1187" fill="#000000" font-size="15">=</text>
+    <text x="292.2" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="300.8" y="1187" fill="#AF00DB" font-size="15">try?</text>
+    <text x="335.2" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="1187" fill="#267F99" font-size="15">@async</text>
+    <text x="395.4" y="1187" fill="#3B3B3B" font-size="15">.</text>
+    <text x="404.0" y="1187" fill="#795E26" font-size="15">with_task_group</text>
+    <text x="533.0" y="1187" fill="#3B3B3B" font-size="15">(</text>
+    <text x="541.6" y="1187" fill="#001080" font-size="15">group</text>
+    <text x="584.6" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="593.2" y="1187" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="610.4" y="1187" fill="#3B3B3B" font-size="15"> </text>
+    <text x="619.0" y="1187" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1209" fill="#6E7681" font-size="15">54</text>
+    <text x="60.0" y="1209" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1209" fill="#001080" font-size="15">group</text>
+    <text x="137.4" y="1209" fill="#3B3B3B" font-size="15">.</text>
+    <text x="146.0" y="1209" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="214.8" y="1209" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="1209" fill="#3B3B3B" font-size="15">)</text>
+    <text x="232.0" y="1209" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="1209" fill="#000000" font-size="15">&lt;|</text>
+    <text x="257.8" y="1209" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="1209" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="1209" fill="#3B3B3B" font-size="15">)</text>
+    <text x="283.6" y="1209" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="1209" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="309.4" y="1209" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="1209" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1231" fill="#6E7681" font-size="15">55</text>
+    <text x="60.0" y="1231" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1231" fill="#008000" font-size="15">// emulate a non-cancellable job,</text>
+    <text x="26" y="1253" fill="#6E7681" font-size="15">56</text>
+    <text x="60.0" y="1253" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1253" fill="#008000" font-size="15">// or a job that happens to be completed on cancellation,</text>
+    <text x="26" y="1275" fill="#6E7681" font-size="15">57</text>
+    <text x="60.0" y="1275" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1275" fill="#008000" font-size="15">// such that discarding the result may lead to data loss</text>
+    <text x="26" y="1297" fill="#6E7681" font-size="15">58</text>
+    <text x="60.0" y="1297" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1297" fill="#267F99" font-size="15">@async</text>
+    <text x="163.2" y="1297" fill="#3B3B3B" font-size="15">.</text>
+    <text x="171.8" y="1297" fill="#795E26" font-size="15">protect_from_cancel</text>
+    <text x="335.2" y="1297" fill="#3B3B3B" font-size="15">(</text>
+    <text x="343.8" y="1297" fill="#3B3B3B" font-size="15">(</text>
+    <text x="352.4" y="1297" fill="#3B3B3B" font-size="15">)</text>
+    <text x="361.0" y="1297" fill="#3B3B3B" font-size="15"> </text>
+    <text x="369.6" y="1297" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="386.8" y="1297" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="1297" fill="#267F99" font-size="15">@async</text>
+    <text x="447.0" y="1297" fill="#3B3B3B" font-size="15">.</text>
+    <text x="455.6" y="1297" fill="#795E26" font-size="15">sleep</text>
+    <text x="498.6" y="1297" fill="#3B3B3B" font-size="15">(</text>
+    <text x="507.2" y="1297" fill="#098658" font-size="15">300</text>
+    <text x="533.0" y="1297" fill="#3B3B3B" font-size="15">)</text>
+    <text x="541.6" y="1297" fill="#3B3B3B" font-size="15">,</text>
+    <text x="550.2" y="1297" fill="#3B3B3B" font-size="15"> </text>
+    <text x="558.8" y="1297" fill="#001080" font-size="15">resume_on_cancel</text>
+    <text x="696.4" y="1297" fill="#000000" font-size="15">=</text>
+    <text x="705.0" y="1297" fill="#0000FF" font-size="15">true</text>
+    <text x="739.4" y="1297" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1319" fill="#6E7681" font-size="15">59</text>
+    <text x="60.0" y="1319" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1319" fill="#008000" font-size="15">// even if control flow enters here normally,</text>
+    <text x="26" y="1341" fill="#6E7681" font-size="15">60</text>
+    <text x="60.0" y="1341" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1341" fill="#008000" font-size="15">// current task and the whole group may be in a cancelled state</text>
+    <text x="26" y="1363" fill="#6E7681" font-size="15">61</text>
+    <text x="60.0" y="1363" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1363" fill="#001080" font-size="15">group</text>
+    <text x="154.6" y="1363" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1363" fill="#795E26" font-size="15">spawn_bg</text>
+    <text x="232.0" y="1363" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="1363" fill="#001080" font-size="15">allow_failure</text>
+    <text x="352.4" y="1363" fill="#000000" font-size="15">=</text>
+    <text x="361.0" y="1363" fill="#0000FF" font-size="15">true</text>
+    <text x="395.4" y="1363" fill="#3B3B3B" font-size="15">)</text>
+    <text x="404.0" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="412.6" y="1363" fill="#000000" font-size="15">&lt;|</text>
+    <text x="429.8" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="438.4" y="1363" fill="#3B3B3B" font-size="15">(</text>
+    <text x="447.0" y="1363" fill="#3B3B3B" font-size="15">)</text>
+    <text x="455.6" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="464.2" y="1363" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="481.4" y="1363" fill="#3B3B3B" font-size="15"> </text>
+    <text x="490.0" y="1363" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="1385" fill="#6E7681" font-size="15">62</text>
+    <text x="60.0" y="1385" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1385" fill="#001080" font-size="15">log</text>
+    <text x="154.6" y="1385" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1385" fill="#795E26" font-size="15">push</text>
+    <text x="197.6" y="1385" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1385" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="1385" fill="#A31515" font-size="15">enter child task after cancelled</text>
+    <text x="490.0" y="1385" fill="#A31515" font-size="15">&quot;</text>
+    <text x="498.6" y="1385" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1407" fill="#6E7681" font-size="15">63</text>
+    <text x="60.0" y="1407" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1407" fill="#267F99" font-size="15">@async</text>
+    <text x="180.4" y="1407" fill="#3B3B3B" font-size="15">.</text>
+    <text x="189.0" y="1407" fill="#795E26" font-size="15">sleep</text>
+    <text x="232.0" y="1407" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="1407" fill="#098658" font-size="15">100</text>
+    <text x="266.4" y="1407" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1429" fill="#6E7681" font-size="15">64</text>
+    <text x="60.0" y="1429" fill="#3B3B3B" font-size="15">        </text>
+    <text x="128.8" y="1429" fill="#001080" font-size="15">log</text>
+    <text x="154.6" y="1429" fill="#3B3B3B" font-size="15">.</text>
+    <text x="163.2" y="1429" fill="#795E26" font-size="15">push</text>
+    <text x="197.6" y="1429" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1429" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="1429" fill="#A31515" font-size="15">child task completed</text>
+    <text x="386.8" y="1429" fill="#A31515" font-size="15">&quot;</text>
+    <text x="395.4" y="1429" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1451" fill="#6E7681" font-size="15">65</text>
+    <text x="60.0" y="1451" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="1451" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1473" fill="#6E7681" font-size="15">66</text>
+    <text x="60.0" y="1473" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1473" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="1495" fill="#6E7681" font-size="15">67</text>
+    <text x="60.0" y="1495" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1495" fill="#267F99" font-size="15">@async</text>
+    <text x="146.0" y="1495" fill="#3B3B3B" font-size="15">.</text>
+    <text x="154.6" y="1495" fill="#795E26" font-size="15">sleep</text>
+    <text x="197.6" y="1495" fill="#3B3B3B" font-size="15">(</text>
+    <text x="206.2" y="1495" fill="#098658" font-size="15">150</text>
+    <text x="232.0" y="1495" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1517" fill="#6E7681" font-size="15">68</text>
+    <text x="60.0" y="1517" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1517" fill="#AF00DB" font-size="15">raise</text>
+    <text x="137.4" y="1517" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1517" fill="#267F99" font-size="15">Failure</text>
+    <text x="206.2" y="1517" fill="#3B3B3B" font-size="15">:</text>
+    <text x="214.8" y="1517" fill="#3B3B3B" font-size="15">:</text>
+    <text x="223.4" y="1517" fill="#267F99" font-size="15">Failure</text>
+    <text x="283.6" y="1517" fill="#3B3B3B" font-size="15">(</text>
+    <text x="292.2" y="1517" fill="#A31515" font-size="15">&quot;</text>
+    <text x="300.8" y="1517" fill="#A31515" font-size="15">failure</text>
+    <text x="361.0" y="1517" fill="#A31515" font-size="15">&quot;</text>
+    <text x="369.6" y="1517" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1539" fill="#6E7681" font-size="15">69</text>
+    <text x="60.0" y="1539" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1539" fill="#3B3B3B" font-size="15">}</text>
+    <text x="85.8" y="1539" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1561" fill="#6E7681" font-size="15">70</text>
+    <text x="60.0" y="1561" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1561" fill="#795E26" font-size="15">json_inspect</text>
+    <text x="180.4" y="1561" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="1561" fill="#001080" font-size="15">log</text>
+    <text x="214.8" y="1561" fill="#3B3B3B" font-size="15">,</text>
+    <text x="223.4" y="1561" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="1561" fill="#001080" font-size="15">content</text>
+    <text x="292.2" y="1561" fill="#000000" font-size="15">=</text>
+    <text x="300.8" y="1561" fill="#3B3B3B" font-size="15">[</text>
+    <text x="309.4" y="1561" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="1561" fill="#A31515" font-size="15">enter child task after cancelled</text>
+    <text x="593.2" y="1561" fill="#A31515" font-size="15">&quot;</text>
+    <text x="601.8" y="1561" fill="#3B3B3B" font-size="15">]</text>
+    <text x="610.4" y="1561" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1583" fill="#6E7681" font-size="15">71</text>
+    <text x="60.0" y="1583" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/config/modern/moon.mod.svg
+++ b/artifacts/previews/config/modern/moon.mod.svg
@@ -63,7 +63,7 @@
     <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
     <text x="60.0" y="219" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="219" fill="#267F99" font-size="15">&quot;preferred-target&quot;</text>
-    <text x="232.0" y="219" fill="#000000" font-size="15">:</text>
+    <text x="232.0" y="219" fill="#3B3B3B" font-size="15">:</text>
     <text x="240.6" y="219" fill="#3B3B3B" font-size="15"> </text>
     <text x="249.2" y="219" fill="#A31515" font-size="15">&quot;</text>
     <text x="257.8" y="219" fill="#A31515" font-size="15">wasm-gc</text>
@@ -72,19 +72,19 @@
     <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
     <text x="60.0" y="241" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="241" fill="#267F99" font-size="15">deps</text>
-    <text x="111.6" y="241" fill="#000000" font-size="15">:</text>
+    <text x="111.6" y="241" fill="#3B3B3B" font-size="15">:</text>
     <text x="120.2" y="241" fill="#3B3B3B" font-size="15"> </text>
     <text x="128.8" y="241" fill="#3B3B3B" font-size="15">{</text>
     <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
     <text x="60.0" y="263" fill="#3B3B3B" font-size="15">    </text>
     <text x="94.4" y="263" fill="#267F99" font-size="15">&quot;moonbitlang/x&quot;</text>
-    <text x="223.4" y="263" fill="#000000" font-size="15">:</text>
+    <text x="223.4" y="263" fill="#3B3B3B" font-size="15">:</text>
     <text x="232.0" y="263" fill="#3B3B3B" font-size="15"> </text>
     <text x="240.6" y="263" fill="#3B3B3B" font-size="15">{</text>
     <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
     <text x="60.0" y="285" fill="#3B3B3B" font-size="15">      </text>
     <text x="111.6" y="285" fill="#267F99" font-size="15">&quot;version&quot;</text>
-    <text x="189.0" y="285" fill="#000000" font-size="15">:</text>
+    <text x="189.0" y="285" fill="#3B3B3B" font-size="15">:</text>
     <text x="197.6" y="285" fill="#3B3B3B" font-size="15"> </text>
     <text x="206.2" y="285" fill="#A31515" font-size="15">&quot;</text>
     <text x="214.8" y="285" fill="#A31515" font-size="15">0.1.0</text>
@@ -101,13 +101,13 @@
     <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
     <text x="60.0" y="351" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="351" fill="#267F99" font-size="15">scripts</text>
-    <text x="137.4" y="351" fill="#000000" font-size="15">:</text>
+    <text x="137.4" y="351" fill="#3B3B3B" font-size="15">:</text>
     <text x="146.0" y="351" fill="#3B3B3B" font-size="15"> </text>
     <text x="154.6" y="351" fill="#3B3B3B" font-size="15">{</text>
     <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
     <text x="60.0" y="373" fill="#3B3B3B" font-size="15">    </text>
     <text x="94.4" y="373" fill="#267F99" font-size="15">&quot;test&quot;</text>
-    <text x="146.0" y="373" fill="#000000" font-size="15">:</text>
+    <text x="146.0" y="373" fill="#3B3B3B" font-size="15">:</text>
     <text x="154.6" y="373" fill="#3B3B3B" font-size="15"> </text>
     <text x="163.2" y="373" fill="#A31515" font-size="15">&quot;</text>
     <text x="171.8" y="373" fill="#A31515" font-size="15">moon test</text>
@@ -124,14 +124,15 @@
     <text x="60.0" y="461" fill="#795E26" font-size="15">rule</text>
     <text x="94.4" y="461" fill="#3B3B3B" font-size="15">(</text>
     <text x="103.0" y="461" fill="#267F99" font-size="15">name</text>
-    <text x="137.4" y="461" fill="#000000" font-size="15">:</text>
+    <text x="137.4" y="461" fill="#3B3B3B" font-size="15">:</text>
     <text x="146.0" y="461" fill="#3B3B3B" font-size="15"> </text>
     <text x="154.6" y="461" fill="#A31515" font-size="15">&quot;</text>
     <text x="163.2" y="461" fill="#A31515" font-size="15">mod-gen</text>
     <text x="223.4" y="461" fill="#A31515" font-size="15">&quot;</text>
-    <text x="232.0" y="461" fill="#3B3B3B" font-size="15">, </text>
+    <text x="232.0" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="240.6" y="461" fill="#3B3B3B" font-size="15"> </text>
     <text x="249.2" y="461" fill="#267F99" font-size="15">command</text>
-    <text x="309.4" y="461" fill="#000000" font-size="15">:</text>
+    <text x="309.4" y="461" fill="#3B3B3B" font-size="15">:</text>
     <text x="318.0" y="461" fill="#3B3B3B" font-size="15"> </text>
     <text x="326.6" y="461" fill="#A31515" font-size="15">&quot;</text>
     <text x="335.2" y="461" fill="#A31515" font-size="15">echo gen</text>

--- a/artifacts/previews/config/modern/moon.pkg.svg
+++ b/artifacts/previews/config/modern/moon.pkg.svg
@@ -47,26 +47,26 @@
     <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
     <text x="60.0" y="219" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="219" fill="#267F99" font-size="15">&quot;is-main&quot;</text>
-    <text x="154.6" y="219" fill="#000000" font-size="15">:</text>
+    <text x="154.6" y="219" fill="#3B3B3B" font-size="15">:</text>
     <text x="163.2" y="219" fill="#3B3B3B" font-size="15"> </text>
     <text x="171.8" y="219" fill="#0000FF" font-size="15">true</text>
     <text x="206.2" y="219" fill="#3B3B3B" font-size="15">,</text>
     <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
     <text x="60.0" y="241" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="241" fill="#267F99" font-size="15">link</text>
-    <text x="111.6" y="241" fill="#000000" font-size="15">:</text>
+    <text x="111.6" y="241" fill="#3B3B3B" font-size="15">:</text>
     <text x="120.2" y="241" fill="#3B3B3B" font-size="15"> </text>
     <text x="128.8" y="241" fill="#3B3B3B" font-size="15">{</text>
     <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
     <text x="60.0" y="263" fill="#3B3B3B" font-size="15">    </text>
     <text x="94.4" y="263" fill="#267F99" font-size="15">&quot;wasm&quot;</text>
-    <text x="146.0" y="263" fill="#000000" font-size="15">:</text>
+    <text x="146.0" y="263" fill="#3B3B3B" font-size="15">:</text>
     <text x="154.6" y="263" fill="#3B3B3B" font-size="15"> </text>
     <text x="163.2" y="263" fill="#3B3B3B" font-size="15">{</text>
     <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
     <text x="60.0" y="285" fill="#3B3B3B" font-size="15">      </text>
     <text x="111.6" y="285" fill="#267F99" font-size="15">&quot;exports&quot;</text>
-    <text x="189.0" y="285" fill="#000000" font-size="15">:</text>
+    <text x="189.0" y="285" fill="#3B3B3B" font-size="15">:</text>
     <text x="197.6" y="285" fill="#3B3B3B" font-size="15"> </text>
     <text x="206.2" y="285" fill="#3B3B3B" font-size="15">[</text>
     <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
@@ -88,7 +88,7 @@
     <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
     <text x="60.0" y="373" fill="#3B3B3B" font-size="15">      </text>
     <text x="111.6" y="373" fill="#267F99" font-size="15">&quot;heap-start-address&quot;</text>
-    <text x="283.6" y="373" fill="#000000" font-size="15">:</text>
+    <text x="283.6" y="373" fill="#3B3B3B" font-size="15">:</text>
     <text x="292.2" y="373" fill="#3B3B3B" font-size="15"> </text>
     <text x="300.8" y="373" fill="#098658" font-size="15">16</text>
     <text x="318.0" y="373" fill="#3B3B3B" font-size="15">,</text>
@@ -107,14 +107,15 @@
     <text x="60.0" y="483" fill="#795E26" font-size="15">rule</text>
     <text x="94.4" y="483" fill="#3B3B3B" font-size="15">(</text>
     <text x="103.0" y="483" fill="#267F99" font-size="15">name</text>
-    <text x="137.4" y="483" fill="#000000" font-size="15">:</text>
+    <text x="137.4" y="483" fill="#3B3B3B" font-size="15">:</text>
     <text x="146.0" y="483" fill="#3B3B3B" font-size="15"> </text>
     <text x="154.6" y="483" fill="#A31515" font-size="15">&quot;</text>
     <text x="163.2" y="483" fill="#A31515" font-size="15">gen</text>
     <text x="189.0" y="483" fill="#A31515" font-size="15">&quot;</text>
-    <text x="197.6" y="483" fill="#3B3B3B" font-size="15">, </text>
+    <text x="197.6" y="483" fill="#3B3B3B" font-size="15">,</text>
+    <text x="206.2" y="483" fill="#3B3B3B" font-size="15"> </text>
     <text x="214.8" y="483" fill="#267F99" font-size="15">command</text>
-    <text x="275.0" y="483" fill="#000000" font-size="15">:</text>
+    <text x="275.0" y="483" fill="#3B3B3B" font-size="15">:</text>
     <text x="283.6" y="483" fill="#3B3B3B" font-size="15"> </text>
     <text x="292.2" y="483" fill="#A31515" font-size="15">&quot;</text>
     <text x="300.8" y="483" fill="#A31515" font-size="15">echo gen</text>
@@ -124,21 +125,23 @@
     <text x="60.0" y="505" fill="#795E26" font-size="15">dev_build</text>
     <text x="137.4" y="505" fill="#3B3B3B" font-size="15">(</text>
     <text x="146.0" y="505" fill="#267F99" font-size="15">rule</text>
-    <text x="180.4" y="505" fill="#000000" font-size="15">:</text>
+    <text x="180.4" y="505" fill="#3B3B3B" font-size="15">:</text>
     <text x="189.0" y="505" fill="#3B3B3B" font-size="15"> </text>
     <text x="197.6" y="505" fill="#A31515" font-size="15">&quot;</text>
     <text x="206.2" y="505" fill="#A31515" font-size="15">gen</text>
     <text x="232.0" y="505" fill="#A31515" font-size="15">&quot;</text>
-    <text x="240.6" y="505" fill="#3B3B3B" font-size="15">, </text>
+    <text x="240.6" y="505" fill="#3B3B3B" font-size="15">,</text>
+    <text x="249.2" y="505" fill="#3B3B3B" font-size="15"> </text>
     <text x="257.8" y="505" fill="#267F99" font-size="15">input</text>
-    <text x="300.8" y="505" fill="#000000" font-size="15">:</text>
+    <text x="300.8" y="505" fill="#3B3B3B" font-size="15">:</text>
     <text x="309.4" y="505" fill="#3B3B3B" font-size="15"> </text>
     <text x="318.0" y="505" fill="#A31515" font-size="15">&quot;</text>
     <text x="326.6" y="505" fill="#A31515" font-size="15">input.txt</text>
     <text x="404.0" y="505" fill="#A31515" font-size="15">&quot;</text>
-    <text x="412.6" y="505" fill="#3B3B3B" font-size="15">, </text>
+    <text x="412.6" y="505" fill="#3B3B3B" font-size="15">,</text>
+    <text x="421.2" y="505" fill="#3B3B3B" font-size="15"> </text>
     <text x="429.8" y="505" fill="#267F99" font-size="15">output</text>
-    <text x="481.4" y="505" fill="#000000" font-size="15">:</text>
+    <text x="481.4" y="505" fill="#3B3B3B" font-size="15">:</text>
     <text x="490.0" y="505" fill="#3B3B3B" font-size="15"> </text>
     <text x="498.6" y="505" fill="#A31515" font-size="15">&quot;</text>
     <text x="507.2" y="505" fill="#A31515" font-size="15">output.txt</text>

--- a/artifacts/previews/core-builtin-guard-feature-test.svg
+++ b/artifacts/previews/core-builtin-guard-feature-test.svg
@@ -1,0 +1,495 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="731" height="1222" viewBox="0 0 731 1222">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#008000" font-size="15">// Source: /Users/baozhiyuan/Workspace/core/builtin/guard_feature_test.mbt</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#008000" font-size="15">// Copyright 2026 International Digital Economy Academy</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#008000" font-size="15">//</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#008000" font-size="15">// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#008000" font-size="15">// you may not use this file except in compliance with the License.</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#008000" font-size="15">// You may obtain a copy of the License at</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#008000" font-size="15">//</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#008000" font-size="15">//     http://www.apache.org/licenses/LICENSE-2.0</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#008000" font-size="15">//</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#008000" font-size="15">// Unless required by applicable law or agreed to in writing, software</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#008000" font-size="15">// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#008000" font-size="15">// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#008000" font-size="15">// See the License for the specific language governing permissions and</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#008000" font-size="15">// limitations under the License.</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#0000FF" font-size="15">enum</text>
+    <text x="94.4" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="395" fill="#267F99" font-size="15">Expr</text>
+    <text x="137.4" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="395" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#267F99" font-size="15">Add</text>
+    <text x="103.0" y="417" fill="#3B3B3B" font-size="15">(</text>
+    <text x="111.6" y="417" fill="#267F99" font-size="15">Expr</text>
+    <text x="146.0" y="417" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="417" fill="#267F99" font-size="15">Expr</text>
+    <text x="197.6" y="417" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="439" fill="#267F99" font-size="15">Sub</text>
+    <text x="103.0" y="439" fill="#3B3B3B" font-size="15">(</text>
+    <text x="111.6" y="439" fill="#267F99" font-size="15">Expr</text>
+    <text x="146.0" y="439" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="439" fill="#267F99" font-size="15">Expr</text>
+    <text x="197.6" y="439" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="461" fill="#267F99" font-size="15">Mul</text>
+    <text x="103.0" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="111.6" y="461" fill="#267F99" font-size="15">Expr</text>
+    <text x="146.0" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="461" fill="#267F99" font-size="15">Expr</text>
+    <text x="197.6" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="483" fill="#267F99" font-size="15">Div</text>
+    <text x="103.0" y="483" fill="#3B3B3B" font-size="15">(</text>
+    <text x="111.6" y="483" fill="#267F99" font-size="15">Expr</text>
+    <text x="146.0" y="483" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="483" fill="#267F99" font-size="15">Expr</text>
+    <text x="197.6" y="483" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="505" fill="#267F99" font-size="15">Lit</text>
+    <text x="103.0" y="505" fill="#3B3B3B" font-size="15">(</text>
+    <text x="111.6" y="505" fill="#267F99" font-size="15">Int</text>
+    <text x="137.4" y="505" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="60.0" y="527" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="527" fill="#267F99" font-size="15">Var</text>
+    <text x="103.0" y="527" fill="#3B3B3B" font-size="15">(</text>
+    <text x="111.6" y="527" fill="#267F99" font-size="15">String</text>
+    <text x="163.2" y="527" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="549" fill="#6E7681" font-size="15">24</text>
+    <text x="60.0" y="549" fill="#3B3B3B" font-size="15">}</text>
+    <text x="68.6" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="77.2" y="549" fill="#0000FF" font-size="15">derive</text>
+    <text x="128.8" y="549" fill="#3B3B3B" font-size="15">(</text>
+    <text x="137.4" y="549" fill="#267F99" font-size="15">Debug</text>
+    <text x="180.4" y="549" fill="#3B3B3B" font-size="15">,</text>
+    <text x="189.0" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="549" fill="#267F99" font-size="15">ToJson</text>
+    <text x="249.2" y="549" fill="#3B3B3B" font-size="15">,</text>
+    <text x="257.8" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="549" fill="#267F99" font-size="15">Eq</text>
+    <text x="283.6" y="549" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="571" fill="#6E7681" font-size="15">25</text>
+    <text x="26" y="593" fill="#6E7681" font-size="15">26</text>
+    <text x="60.0" y="593" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="615" fill="#6E7681" font-size="15">27</text>
+    <text x="60.0" y="615" fill="#0000FF" font-size="15">fn</text>
+    <text x="77.2" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="85.8" y="615" fill="#795E26" font-size="15">simplify</text>
+    <text x="154.6" y="615" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="615" fill="#001080" font-size="15">e</text>
+    <text x="171.8" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="615" fill="#3B3B3B" font-size="15">:</text>
+    <text x="189.0" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="615" fill="#267F99" font-size="15">Expr</text>
+    <text x="232.0" y="615" fill="#3B3B3B" font-size="15">)</text>
+    <text x="240.6" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="249.2" y="615" fill="#0000FF" font-size="15">-&gt;</text>
+    <text x="266.4" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="615" fill="#267F99" font-size="15">Expr</text>
+    <text x="309.4" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="318.0" y="615" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="637" fill="#6E7681" font-size="15">28</text>
+    <text x="60.0" y="637" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="637" fill="#AF00DB" font-size="15">match</text>
+    <text x="120.2" y="637" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="637" fill="#001080" font-size="15">e</text>
+    <text x="137.4" y="637" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="637" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="659" fill="#6E7681" font-size="15">29</text>
+    <text x="60.0" y="659" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="659" fill="#267F99" font-size="15">Add</text>
+    <text x="120.2" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="659" fill="#001080" font-size="15">e1</text>
+    <text x="146.0" y="659" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="659" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="659" fill="#267F99" font-size="15">Lit</text>
+    <text x="189.0" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="197.6" y="659" fill="#098658" font-size="15">0</text>
+    <text x="206.2" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="214.8" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="659" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="659" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="249.2" y="659" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="659" fill="#795E26" font-size="15">simplify</text>
+    <text x="326.6" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="335.2" y="659" fill="#001080" font-size="15">e1</text>
+    <text x="352.4" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="681" fill="#6E7681" font-size="15">30</text>
+    <text x="60.0" y="681" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="681" fill="#267F99" font-size="15">Add</text>
+    <text x="120.2" y="681" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="681" fill="#267F99" font-size="15">Lit</text>
+    <text x="154.6" y="681" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="681" fill="#098658" font-size="15">0</text>
+    <text x="171.8" y="681" fill="#3B3B3B" font-size="15">)</text>
+    <text x="180.4" y="681" fill="#3B3B3B" font-size="15">,</text>
+    <text x="189.0" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="681" fill="#001080" font-size="15">e2</text>
+    <text x="214.8" y="681" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="681" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="249.2" y="681" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="681" fill="#795E26" font-size="15">simplify</text>
+    <text x="326.6" y="681" fill="#3B3B3B" font-size="15">(</text>
+    <text x="335.2" y="681" fill="#001080" font-size="15">e2</text>
+    <text x="352.4" y="681" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="703" fill="#6E7681" font-size="15">31</text>
+    <text x="60.0" y="703" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="703" fill="#267F99" font-size="15">Mul</text>
+    <text x="120.2" y="703" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="703" fill="#001080" font-size="15">e1</text>
+    <text x="146.0" y="703" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="703" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="703" fill="#267F99" font-size="15">Lit</text>
+    <text x="189.0" y="703" fill="#3B3B3B" font-size="15">(</text>
+    <text x="197.6" y="703" fill="#098658" font-size="15">1</text>
+    <text x="206.2" y="703" fill="#3B3B3B" font-size="15">)</text>
+    <text x="214.8" y="703" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="703" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="703" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="249.2" y="703" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="703" fill="#795E26" font-size="15">simplify</text>
+    <text x="326.6" y="703" fill="#3B3B3B" font-size="15">(</text>
+    <text x="335.2" y="703" fill="#001080" font-size="15">e1</text>
+    <text x="352.4" y="703" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="725" fill="#6E7681" font-size="15">32</text>
+    <text x="60.0" y="725" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="725" fill="#267F99" font-size="15">Mul</text>
+    <text x="120.2" y="725" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="725" fill="#267F99" font-size="15">Lit</text>
+    <text x="154.6" y="725" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="725" fill="#098658" font-size="15">1</text>
+    <text x="171.8" y="725" fill="#3B3B3B" font-size="15">)</text>
+    <text x="180.4" y="725" fill="#3B3B3B" font-size="15">,</text>
+    <text x="189.0" y="725" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="725" fill="#001080" font-size="15">e2</text>
+    <text x="214.8" y="725" fill="#3B3B3B" font-size="15">)</text>
+    <text x="223.4" y="725" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="725" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="249.2" y="725" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="725" fill="#795E26" font-size="15">simplify</text>
+    <text x="326.6" y="725" fill="#3B3B3B" font-size="15">(</text>
+    <text x="335.2" y="725" fill="#001080" font-size="15">e2</text>
+    <text x="352.4" y="725" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="747" fill="#6E7681" font-size="15">33</text>
+    <text x="60.0" y="747" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="747" fill="#267F99" font-size="15">Sub</text>
+    <text x="120.2" y="747" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="747" fill="#001080" font-size="15">e1</text>
+    <text x="146.0" y="747" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="747" fill="#001080" font-size="15">e2</text>
+    <text x="180.4" y="747" fill="#3B3B3B" font-size="15">)</text>
+    <text x="189.0" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="747" fill="#AF00DB" font-size="15">if</text>
+    <text x="214.8" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="747" fill="#001080" font-size="15">e1</text>
+    <text x="240.6" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="249.2" y="747" fill="#000000" font-size="15">==</text>
+    <text x="266.4" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="747" fill="#001080" font-size="15">e2</text>
+    <text x="292.2" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="300.8" y="747" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="318.0" y="747" fill="#3B3B3B" font-size="15"> </text>
+    <text x="326.6" y="747" fill="#267F99" font-size="15">Lit</text>
+    <text x="352.4" y="747" fill="#3B3B3B" font-size="15">(</text>
+    <text x="361.0" y="747" fill="#098658" font-size="15">0</text>
+    <text x="369.6" y="747" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="769" fill="#6E7681" font-size="15">34</text>
+    <text x="60.0" y="769" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="769" fill="#008000" font-size="15">// guard is useful for in-exhaustive match</text>
+    <text x="26" y="791" fill="#6E7681" font-size="15">35</text>
+    <text x="60.0" y="791" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="791" fill="#008000" font-size="15">// otherwise the else condition will be duplicated</text>
+    <text x="26" y="813" fill="#6E7681" font-size="15">36</text>
+    <text x="60.0" y="813" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="813" fill="#267F99" font-size="15">Mul</text>
+    <text x="120.2" y="813" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="813" fill="#267F99" font-size="15">Lit</text>
+    <text x="154.6" y="813" fill="#3B3B3B" font-size="15">(</text>
+    <text x="163.2" y="813" fill="#098658" font-size="15">0</text>
+    <text x="171.8" y="813" fill="#3B3B3B" font-size="15">)</text>
+    <text x="180.4" y="813" fill="#3B3B3B" font-size="15">,</text>
+    <text x="189.0" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="813" fill="#0000FF" font-size="15">_</text>
+    <text x="206.2" y="813" fill="#3B3B3B" font-size="15">)</text>
+    <text x="214.8" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="813" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="240.6" y="813" fill="#3B3B3B" font-size="15"> </text>
+    <text x="249.2" y="813" fill="#267F99" font-size="15">Lit</text>
+    <text x="275.0" y="813" fill="#3B3B3B" font-size="15">(</text>
+    <text x="283.6" y="813" fill="#098658" font-size="15">0</text>
+    <text x="292.2" y="813" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="835" fill="#6E7681" font-size="15">37</text>
+    <text x="60.0" y="835" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="835" fill="#267F99" font-size="15">Mul</text>
+    <text x="120.2" y="835" fill="#3B3B3B" font-size="15">(</text>
+    <text x="128.8" y="835" fill="#0000FF" font-size="15">_</text>
+    <text x="137.4" y="835" fill="#3B3B3B" font-size="15">,</text>
+    <text x="146.0" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="835" fill="#267F99" font-size="15">Lit</text>
+    <text x="180.4" y="835" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="835" fill="#098658" font-size="15">0</text>
+    <text x="197.6" y="835" fill="#3B3B3B" font-size="15">)</text>
+    <text x="206.2" y="835" fill="#3B3B3B" font-size="15">)</text>
+    <text x="214.8" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="835" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="240.6" y="835" fill="#3B3B3B" font-size="15"> </text>
+    <text x="249.2" y="835" fill="#267F99" font-size="15">Lit</text>
+    <text x="275.0" y="835" fill="#3B3B3B" font-size="15">(</text>
+    <text x="283.6" y="835" fill="#098658" font-size="15">0</text>
+    <text x="292.2" y="835" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="857" fill="#6E7681" font-size="15">38</text>
+    <text x="60.0" y="857" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="857" fill="#0000FF" font-size="15">_</text>
+    <text x="103.0" y="857" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="857" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="128.8" y="857" fill="#3B3B3B" font-size="15"> </text>
+    <text x="137.4" y="857" fill="#001080" font-size="15">e</text>
+    <text x="26" y="879" fill="#6E7681" font-size="15">39</text>
+    <text x="60.0" y="879" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="879" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="901" fill="#6E7681" font-size="15">40</text>
+    <text x="60.0" y="901" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="923" fill="#6E7681" font-size="15">41</text>
+    <text x="26" y="945" fill="#6E7681" font-size="15">42</text>
+    <text x="60.0" y="945" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="967" fill="#6E7681" font-size="15">43</text>
+    <text x="60.0" y="967" fill="#0000FF" font-size="15">test</text>
+    <text x="94.4" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="967" fill="#A31515" font-size="15">&quot;</text>
+    <text x="111.6" y="967" fill="#A31515" font-size="15">simplify</text>
+    <text x="180.4" y="967" fill="#A31515" font-size="15">&quot;</text>
+    <text x="189.0" y="967" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="967" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="989" fill="#6E7681" font-size="15">44</text>
+    <text x="60.0" y="989" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="989" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="989" fill="#001080" font-size="15">_ignored</text>
+    <text x="180.4" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="989" fill="#000000" font-size="15">=</text>
+    <text x="197.6" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="989" fill="#267F99" font-size="15">Add</text>
+    <text x="232.0" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="989" fill="#267F99" font-size="15">Div</text>
+    <text x="266.4" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="989" fill="#267F99" font-size="15">Lit</text>
+    <text x="300.8" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="309.4" y="989" fill="#098658" font-size="15">1</text>
+    <text x="318.0" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="326.6" y="989" fill="#3B3B3B" font-size="15">,</text>
+    <text x="335.2" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="989" fill="#267F99" font-size="15">Lit</text>
+    <text x="369.6" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="378.2" y="989" fill="#098658" font-size="15">2</text>
+    <text x="386.8" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="395.4" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="404.0" y="989" fill="#3B3B3B" font-size="15">,</text>
+    <text x="412.6" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="421.2" y="989" fill="#267F99" font-size="15">Div</text>
+    <text x="447.0" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="455.6" y="989" fill="#267F99" font-size="15">Lit</text>
+    <text x="481.4" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="490.0" y="989" fill="#098658" font-size="15">1</text>
+    <text x="498.6" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="507.2" y="989" fill="#3B3B3B" font-size="15">,</text>
+    <text x="515.8" y="989" fill="#3B3B3B" font-size="15"> </text>
+    <text x="524.4" y="989" fill="#267F99" font-size="15">Lit</text>
+    <text x="550.2" y="989" fill="#3B3B3B" font-size="15">(</text>
+    <text x="558.8" y="989" fill="#098658" font-size="15">2</text>
+    <text x="567.4" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="576.0" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="584.6" y="989" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1011" fill="#6E7681" font-size="15">45</text>
+    <text x="60.0" y="1011" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1011" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1011" fill="#001080" font-size="15">e</text>
+    <text x="120.2" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="1011" fill="#000000" font-size="15">=</text>
+    <text x="137.4" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="1011" fill="#267F99" font-size="15">Sub</text>
+    <text x="171.8" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="180.4" y="1011" fill="#267F99" font-size="15">Mul</text>
+    <text x="206.2" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="1011" fill="#267F99" font-size="15">Lit</text>
+    <text x="240.6" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="1011" fill="#098658" font-size="15">1</text>
+    <text x="257.8" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="266.4" y="1011" fill="#3B3B3B" font-size="15">,</text>
+    <text x="275.0" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="1011" fill="#267F99" font-size="15">Var</text>
+    <text x="309.4" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="318.0" y="1011" fill="#A31515" font-size="15">&quot;</text>
+    <text x="326.6" y="1011" fill="#A31515" font-size="15">x</text>
+    <text x="335.2" y="1011" fill="#A31515" font-size="15">&quot;</text>
+    <text x="343.8" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="352.4" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="361.0" y="1011" fill="#3B3B3B" font-size="15">,</text>
+    <text x="369.6" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="378.2" y="1011" fill="#267F99" font-size="15">Mul</text>
+    <text x="404.0" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="412.6" y="1011" fill="#267F99" font-size="15">Lit</text>
+    <text x="438.4" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="447.0" y="1011" fill="#098658" font-size="15">1</text>
+    <text x="455.6" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="464.2" y="1011" fill="#3B3B3B" font-size="15">,</text>
+    <text x="472.8" y="1011" fill="#3B3B3B" font-size="15"> </text>
+    <text x="481.4" y="1011" fill="#267F99" font-size="15">Var</text>
+    <text x="507.2" y="1011" fill="#3B3B3B" font-size="15">(</text>
+    <text x="515.8" y="1011" fill="#A31515" font-size="15">&quot;</text>
+    <text x="524.4" y="1011" fill="#A31515" font-size="15">x</text>
+    <text x="533.0" y="1011" fill="#A31515" font-size="15">&quot;</text>
+    <text x="541.6" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="550.2" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="558.8" y="1011" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1033" fill="#6E7681" font-size="15">46</text>
+    <text x="60.0" y="1033" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1033" fill="#267F99" font-size="15">@json</text>
+    <text x="120.2" y="1033" fill="#3B3B3B" font-size="15">.</text>
+    <text x="128.8" y="1033" fill="#795E26" font-size="15">json_inspect</text>
+    <text x="232.0" y="1033" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="1033" fill="#001080" font-size="15">e</text>
+    <text x="249.2" y="1033" fill="#3B3B3B" font-size="15">,</text>
+    <text x="257.8" y="1033" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="1033" fill="#001080" font-size="15">content</text>
+    <text x="326.6" y="1033" fill="#000000" font-size="15">=</text>
+    <text x="335.2" y="1033" fill="#3B3B3B" font-size="15">[</text>
+    <text x="26" y="1055" fill="#6E7681" font-size="15">47</text>
+    <text x="60.0" y="1055" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1055" fill="#A31515" font-size="15">&quot;</text>
+    <text x="103.0" y="1055" fill="#A31515" font-size="15">Sub</text>
+    <text x="128.8" y="1055" fill="#A31515" font-size="15">&quot;</text>
+    <text x="137.4" y="1055" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="1077" fill="#6E7681" font-size="15">48</text>
+    <text x="60.0" y="1077" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1077" fill="#3B3B3B" font-size="15">[</text>
+    <text x="103.0" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="111.6" y="1077" fill="#A31515" font-size="15">Mul</text>
+    <text x="137.4" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="146.0" y="1077" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="1077" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="1077" fill="#3B3B3B" font-size="15">[</text>
+    <text x="171.8" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="180.4" y="1077" fill="#A31515" font-size="15">Lit</text>
+    <text x="206.2" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="1077" fill="#3B3B3B" font-size="15">,</text>
+    <text x="223.4" y="1077" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="1077" fill="#098658" font-size="15">1</text>
+    <text x="240.6" y="1077" fill="#3B3B3B" font-size="15">]</text>
+    <text x="249.2" y="1077" fill="#3B3B3B" font-size="15">,</text>
+    <text x="257.8" y="1077" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="1077" fill="#3B3B3B" font-size="15">[</text>
+    <text x="275.0" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="283.6" y="1077" fill="#A31515" font-size="15">Var</text>
+    <text x="309.4" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="1077" fill="#3B3B3B" font-size="15">,</text>
+    <text x="326.6" y="1077" fill="#3B3B3B" font-size="15"> </text>
+    <text x="335.2" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="343.8" y="1077" fill="#A31515" font-size="15">x</text>
+    <text x="352.4" y="1077" fill="#A31515" font-size="15">&quot;</text>
+    <text x="361.0" y="1077" fill="#3B3B3B" font-size="15">]</text>
+    <text x="369.6" y="1077" fill="#3B3B3B" font-size="15">]</text>
+    <text x="378.2" y="1077" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="1099" fill="#6E7681" font-size="15">49</text>
+    <text x="60.0" y="1099" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="1099" fill="#3B3B3B" font-size="15">[</text>
+    <text x="103.0" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="111.6" y="1099" fill="#A31515" font-size="15">Mul</text>
+    <text x="137.4" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="146.0" y="1099" fill="#3B3B3B" font-size="15">,</text>
+    <text x="154.6" y="1099" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="1099" fill="#3B3B3B" font-size="15">[</text>
+    <text x="171.8" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="180.4" y="1099" fill="#A31515" font-size="15">Lit</text>
+    <text x="206.2" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="214.8" y="1099" fill="#3B3B3B" font-size="15">,</text>
+    <text x="223.4" y="1099" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="1099" fill="#098658" font-size="15">1</text>
+    <text x="240.6" y="1099" fill="#3B3B3B" font-size="15">]</text>
+    <text x="249.2" y="1099" fill="#3B3B3B" font-size="15">,</text>
+    <text x="257.8" y="1099" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="1099" fill="#3B3B3B" font-size="15">[</text>
+    <text x="275.0" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="283.6" y="1099" fill="#A31515" font-size="15">Var</text>
+    <text x="309.4" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="318.0" y="1099" fill="#3B3B3B" font-size="15">,</text>
+    <text x="326.6" y="1099" fill="#3B3B3B" font-size="15"> </text>
+    <text x="335.2" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="343.8" y="1099" fill="#A31515" font-size="15">x</text>
+    <text x="352.4" y="1099" fill="#A31515" font-size="15">&quot;</text>
+    <text x="361.0" y="1099" fill="#3B3B3B" font-size="15">]</text>
+    <text x="369.6" y="1099" fill="#3B3B3B" font-size="15">]</text>
+    <text x="378.2" y="1099" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="1121" fill="#6E7681" font-size="15">50</text>
+    <text x="60.0" y="1121" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1121" fill="#3B3B3B" font-size="15">]</text>
+    <text x="85.8" y="1121" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1143" fill="#6E7681" font-size="15">51</text>
+    <text x="60.0" y="1143" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1143" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="1143" fill="#001080" font-size="15">simplified</text>
+    <text x="197.6" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="1143" fill="#000000" font-size="15">=</text>
+    <text x="214.8" y="1143" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="1143" fill="#795E26" font-size="15">simplify</text>
+    <text x="292.2" y="1143" fill="#3B3B3B" font-size="15">(</text>
+    <text x="300.8" y="1143" fill="#001080" font-size="15">e</text>
+    <text x="309.4" y="1143" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1165" fill="#6E7681" font-size="15">52</text>
+    <text x="60.0" y="1165" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="1165" fill="#267F99" font-size="15">@json</text>
+    <text x="120.2" y="1165" fill="#3B3B3B" font-size="15">.</text>
+    <text x="128.8" y="1165" fill="#795E26" font-size="15">json_inspect</text>
+    <text x="232.0" y="1165" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="1165" fill="#001080" font-size="15">simplified</text>
+    <text x="326.6" y="1165" fill="#3B3B3B" font-size="15">,</text>
+    <text x="335.2" y="1165" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="1165" fill="#001080" font-size="15">content</text>
+    <text x="404.0" y="1165" fill="#000000" font-size="15">=</text>
+    <text x="412.6" y="1165" fill="#3B3B3B" font-size="15">[</text>
+    <text x="421.2" y="1165" fill="#A31515" font-size="15">&quot;</text>
+    <text x="429.8" y="1165" fill="#A31515" font-size="15">Lit</text>
+    <text x="455.6" y="1165" fill="#A31515" font-size="15">&quot;</text>
+    <text x="464.2" y="1165" fill="#3B3B3B" font-size="15">,</text>
+    <text x="472.8" y="1165" fill="#3B3B3B" font-size="15"> </text>
+    <text x="481.4" y="1165" fill="#098658" font-size="15">0</text>
+    <text x="490.0" y="1165" fill="#3B3B3B" font-size="15">]</text>
+    <text x="498.6" y="1165" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="1187" fill="#6E7681" font-size="15">53</text>
+    <text x="60.0" y="1187" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/core-bytes-feature-pipe-test.svg
+++ b/artifacts/previews/core-bytes-feature-pipe-test.svg
@@ -1,0 +1,193 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="731" height="936" viewBox="0 0 731 936">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#008000" font-size="15">// Source: /Users/baozhiyuan/Workspace/core/bytes/feature_pipe_test.mbt</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#008000" font-size="15">// Copyright 2026 International Digital Economy Academy</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#008000" font-size="15">//</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#008000" font-size="15">// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#008000" font-size="15">// you may not use this file except in compliance with the License.</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#008000" font-size="15">// You may obtain a copy of the License at</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#008000" font-size="15">//</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#008000" font-size="15">//     http://www.apache.org/licenses/LICENSE-2.0</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#008000" font-size="15">//</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#008000" font-size="15">// Unless required by applicable law or agreed to in writing, software</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#008000" font-size="15">// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#008000" font-size="15">// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#008000" font-size="15">// See the License for the specific language governing permissions and</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#008000" font-size="15">// limitations under the License.</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#0000FF" font-size="15">test</text>
+    <text x="94.4" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="111.6" y="395" fill="#A31515" font-size="15">feature pipe</text>
+    <text x="214.8" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="223.4" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="395" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="417" fill="#001080" font-size="15">b</text>
+    <text x="120.2" y="417" fill="#000000" font-size="15"> :</text>
+    <text x="137.4" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="417" fill="#267F99" font-size="15">Bytes</text>
+    <text x="189.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="417" fill="#000000" font-size="15">=</text>
+    <text x="206.2" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="214.8" y="417" fill="#A31515" font-size="15">b&quot;hello&quot;</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="439" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="439" fill="#0000FF" font-size="15">mut</text>
+    <text x="137.4" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="439" fill="#001080" font-size="15">u</text>
+    <text x="154.6" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="439" fill="#000000" font-size="15">=</text>
+    <text x="171.8" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="439" fill="#267F99" font-size="15">Bytes</text>
+    <text x="223.4" y="439" fill="#3B3B3B" font-size="15">:</text>
+    <text x="232.0" y="439" fill="#3B3B3B" font-size="15">:</text>
+    <text x="240.6" y="439" fill="#795E26" font-size="15">new</text>
+    <text x="266.4" y="439" fill="#3B3B3B" font-size="15">(</text>
+    <text x="275.0" y="439" fill="#001080" font-size="15">b</text>
+    <text x="283.6" y="439" fill="#3B3B3B" font-size="15">.</text>
+    <text x="292.2" y="439" fill="#795E26" font-size="15">length</text>
+    <text x="343.8" y="439" fill="#3B3B3B" font-size="15">(</text>
+    <text x="352.4" y="439" fill="#3B3B3B" font-size="15">)</text>
+    <text x="361.0" y="439" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="461" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="461" fill="#001080" font-size="15">v</text>
+    <text x="120.2" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="461" fill="#000000" font-size="15">=</text>
+    <text x="137.4" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="461" fill="#001080" font-size="15">b</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="483" fill="#000000" font-size="15">|&gt;</text>
+    <text x="111.6" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="120.2" y="483" fill="#001080" font-size="15">x</text>
+    <text x="128.8" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="137.4" y="483" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="154.6" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="483" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="505" fill="#001080" font-size="15">u</text>
+    <text x="120.2" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="505" fill="#000000" font-size="15">=</text>
+    <text x="137.4" y="505" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="505" fill="#001080" font-size="15">x</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="60.0" y="527" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="527" fill="#001080" font-size="15">x</text>
+    <text x="26" y="549" fill="#6E7681" font-size="15">24</text>
+    <text x="60.0" y="549" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="549" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="571" fill="#6E7681" font-size="15">25</text>
+    <text x="60.0" y="571" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="571" fill="#000000" font-size="15">|&gt;</text>
+    <text x="111.6" y="571" fill="#3B3B3B" font-size="15"> </text>
+    <text x="120.2" y="571" fill="#267F99" font-size="15">Bytes</text>
+    <text x="163.2" y="571" fill="#3B3B3B" font-size="15">:</text>
+    <text x="171.8" y="571" fill="#3B3B3B" font-size="15">:</text>
+    <text x="180.4" y="571" fill="#795E26" font-size="15">length</text>
+    <text x="232.0" y="571" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="571" fill="#3B3B3B" font-size="15">)</text>
+    <text x="249.2" y="571" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="571" fill="#008000" font-size="15">// test _.length()</text>
+    <text x="26" y="593" fill="#6E7681" font-size="15">26</text>
+    <text x="60.0" y="593" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="593" fill="#000000" font-size="15">|&gt;</text>
+    <text x="111.6" y="593" fill="#3B3B3B" font-size="15"> </text>
+    <text x="120.2" y="593" fill="#267F99" font-size="15">Int</text>
+    <text x="146.0" y="593" fill="#3B3B3B" font-size="15">:</text>
+    <text x="154.6" y="593" fill="#3B3B3B" font-size="15">:</text>
+    <text x="163.2" y="593" fill="#795E26" font-size="15">to_int64</text>
+    <text x="232.0" y="593" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="593" fill="#3B3B3B" font-size="15">)</text>
+    <text x="249.2" y="593" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="593" fill="#008000" font-size="15">// test _.to_int()</text>
+    <text x="26" y="615" fill="#6E7681" font-size="15">27</text>
+    <text x="60.0" y="615" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="615" fill="#795E26" font-size="15">inspect</text>
+    <text x="137.4" y="615" fill="#3B3B3B" font-size="15">(</text>
+    <text x="146.0" y="615" fill="#001080" font-size="15">v</text>
+    <text x="154.6" y="615" fill="#3B3B3B" font-size="15">,</text>
+    <text x="163.2" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="615" fill="#001080" font-size="15">content</text>
+    <text x="232.0" y="615" fill="#000000" font-size="15">=</text>
+    <text x="240.6" y="615" fill="#A31515" font-size="15">&quot;</text>
+    <text x="249.2" y="615" fill="#A31515" font-size="15">5</text>
+    <text x="257.8" y="615" fill="#A31515" font-size="15">&quot;</text>
+    <text x="266.4" y="615" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="637" fill="#6E7681" font-size="15">28</text>
+    <text x="60.0" y="637" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="637" fill="#795E26" font-size="15">inspect</text>
+    <text x="137.4" y="637" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="659" fill="#6E7681" font-size="15">29</text>
+    <text x="60.0" y="659" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="659" fill="#001080" font-size="15">b</text>
+    <text x="103.0" y="659" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="681" fill="#6E7681" font-size="15">30</text>
+    <text x="60.0" y="681" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="681" fill="#001080" font-size="15">content</text>
+    <text x="154.6" y="681" fill="#000000" font-size="15">=</text>
+    <text x="163.2" y="681" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="703" fill="#6E7681" font-size="15">31</text>
+    <text x="60.0" y="703" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="703" fill="#A31515" font-size="15">#|b&quot;hello&quot;</text>
+    <text x="26" y="725" fill="#6E7681" font-size="15">32</text>
+    <text x="60.0" y="725" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="725" fill="#3B3B3B" font-size="15">)</text>
+    <text x="103.0" y="725" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="747" fill="#6E7681" font-size="15">33</text>
+    <text x="60.0" y="747" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="747" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="769" fill="#6E7681" font-size="15">34</text>
+    <text x="60.0" y="769" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="769" fill="#795E26" font-size="15">inspect</text>
+    <text x="137.4" y="769" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="791" fill="#6E7681" font-size="15">35</text>
+    <text x="60.0" y="791" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="791" fill="#001080" font-size="15">u</text>
+    <text x="103.0" y="791" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="813" fill="#6E7681" font-size="15">36</text>
+    <text x="60.0" y="813" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="813" fill="#001080" font-size="15">content</text>
+    <text x="154.6" y="813" fill="#000000" font-size="15">=</text>
+    <text x="163.2" y="813" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="835" fill="#6E7681" font-size="15">37</text>
+    <text x="60.0" y="835" fill="#3B3B3B" font-size="15">      </text>
+    <text x="111.6" y="835" fill="#A31515" font-size="15">#|b&quot;hello&quot;</text>
+    <text x="26" y="857" fill="#6E7681" font-size="15">38</text>
+    <text x="60.0" y="857" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="857" fill="#3B3B3B" font-size="15">)</text>
+    <text x="103.0" y="857" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="879" fill="#6E7681" font-size="15">39</text>
+    <text x="60.0" y="879" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="879" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="901" fill="#6E7681" font-size="15">40</text>
+    <text x="60.0" y="901" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/core-bytes-view-pattern-test.svg
+++ b/artifacts/previews/core-bytes-view-pattern-test.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="731" height="562" viewBox="0 0 731 562">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#008000" font-size="15">// Source: /Users/baozhiyuan/Workspace/core/bytes/view_pattern_test.mbt</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#008000" font-size="15">// Copyright 2026 International Digital Economy Academy</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#008000" font-size="15">//</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#008000" font-size="15">// Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#008000" font-size="15">// you may not use this file except in compliance with the License.</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#008000" font-size="15">// You may obtain a copy of the License at</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#008000" font-size="15">//</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#008000" font-size="15">//     http://www.apache.org/licenses/LICENSE-2.0</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#008000" font-size="15">//</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#008000" font-size="15">// Unless required by applicable law or agreed to in writing, software</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#008000" font-size="15">// distributed under the License is distributed on an &quot;AS IS&quot; BASIS,</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#008000" font-size="15">// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#008000" font-size="15">// See the License for the specific language governing permissions and</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#008000" font-size="15">// limitations under the License.</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#008000" font-size="15">///|</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#0000FF" font-size="15">test</text>
+    <text x="94.4" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="111.6" y="395" fill="#A31515" font-size="15">View::pattern</text>
+    <text x="223.4" y="395" fill="#A31515" font-size="15">&quot;</text>
+    <text x="232.0" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="395" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="417" fill="#001080" font-size="15">view</text>
+    <text x="146.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="417" fill="#000000" font-size="15">=</text>
+    <text x="163.2" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="417" fill="#A31515" font-size="15">b&quot;\x01\x02\x03&quot;</text>
+    <text x="300.8" y="417" fill="#3B3B3B" font-size="15">[</text>
+    <text x="309.4" y="417" fill="#3B3B3B" font-size="15">:</text>
+    <text x="318.0" y="417" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="439" fill="#AF00DB" font-size="15">match</text>
+    <text x="120.2" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="439" fill="#001080" font-size="15">view</text>
+    <text x="163.2" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="439" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="461" fill="#3B3B3B" font-size="15">[</text>
+    <text x="103.0" y="461" fill="#098658" font-size="15">0x01</text>
+    <text x="137.4" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="146.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="461" fill="#098658" font-size="15">0x02</text>
+    <text x="189.0" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="197.6" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="461" fill="#000000" font-size="15">..</text>
+    <text x="223.4" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="232.0" y="461" fill="#001080" font-size="15">rest</text>
+    <text x="266.4" y="461" fill="#3B3B3B" font-size="15">]</text>
+    <text x="275.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="461" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="300.8" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="461" fill="#795E26" font-size="15">inspect</text>
+    <text x="369.6" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="378.2" y="461" fill="#001080" font-size="15">rest</text>
+    <text x="412.6" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="421.2" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="429.8" y="461" fill="#001080" font-size="15">content</text>
+    <text x="490.0" y="461" fill="#000000" font-size="15">=</text>
+    <text x="498.6" y="461" fill="#A31515" font-size="15">&quot;</text>
+    <text x="507.2" y="461" fill="#A31515" font-size="15">b</text>
+    <text x="515.8" y="461" fill="#EE0000" font-size="15">\&quot;</text>
+    <text x="533.0" y="461" fill="#EE0000" font-size="15">\\</text>
+    <text x="550.2" y="461" fill="#A31515" font-size="15">x03</text>
+    <text x="576.0" y="461" fill="#EE0000" font-size="15">\&quot;</text>
+    <text x="593.2" y="461" fill="#A31515" font-size="15">&quot;</text>
+    <text x="601.8" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="483" fill="#0000FF" font-size="15">_</text>
+    <text x="103.0" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="483" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="128.8" y="483" fill="#3B3B3B" font-size="15"> </text>
+    <text x="137.4" y="483" fill="#795E26" font-size="15">abort</text>
+    <text x="180.4" y="483" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="483" fill="#A31515" font-size="15">&quot;</text>
+    <text x="197.6" y="483" fill="#A31515" font-size="15">should not happen</text>
+    <text x="343.8" y="483" fill="#A31515" font-size="15">&quot;</text>
+    <text x="352.4" y="483" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="505" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="60.0" y="527" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/core-value-range.svg
+++ b/artifacts/previews/core-value-range.svg
@@ -65,7 +65,7 @@
     <text x="85.8" y="285" fill="#3B3B3B" font-size="15"> </text>
     <text x="94.4" y="285" fill="#0000FF" font-size="15">fn</text>
     <text x="111.6" y="285" fill="#3B3B3B" font-size="15"> </text>
-    <text x="120.2" y="285" fill="#795E26" font-size="15">ValueRange</text>
+    <text x="120.2" y="285" fill="#267F99" font-size="15">ValueRange</text>
     <text x="206.2" y="285" fill="#3B3B3B" font-size="15">:</text>
     <text x="214.8" y="285" fill="#3B3B3B" font-size="15">:</text>
     <text x="223.4" y="285" fill="#267F99" font-size="15">ValueRange</text>
@@ -117,7 +117,7 @@
     <text x="85.8" y="417" fill="#3B3B3B" font-size="15"> </text>
     <text x="94.4" y="417" fill="#0000FF" font-size="15">fn</text>
     <text x="111.6" y="417" fill="#3B3B3B" font-size="15"> </text>
-    <text x="120.2" y="417" fill="#795E26" font-size="15">ValueRange</text>
+    <text x="120.2" y="417" fill="#267F99" font-size="15">ValueRange</text>
     <text x="206.2" y="417" fill="#3B3B3B" font-size="15">:</text>
     <text x="214.8" y="417" fill="#3B3B3B" font-size="15">:</text>
     <text x="223.4" y="417" fill="#795E26" font-size="15">single</text>

--- a/artifacts/previews/generated-source.svg
+++ b/artifacts/previews/generated-source.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="671" height="408" viewBox="0 0 671 408">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#0000FF" font-size="15">fn</text>
+    <text x="77.2" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="85.8" y="43" fill="#795E26" font-size="15">generated_source</text>
+    <text x="223.4" y="43" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="65" fill="#001080" font-size="15">base</text>
+    <text x="111.6" y="65" fill="#3B3B3B" font-size="15">~</text>
+    <text x="120.2" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="65" fill="#3B3B3B" font-size="15">:</text>
+    <text x="137.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="65" fill="#267F99" font-size="15">String</text>
+    <text x="197.6" y="65" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="87" fill="#001080" font-size="15">function_name</text>
+    <text x="189.0" y="87" fill="#3B3B3B" font-size="15">~</text>
+    <text x="197.6" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="87" fill="#3B3B3B" font-size="15">:</text>
+    <text x="214.8" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="87" fill="#267F99" font-size="15">String</text>
+    <text x="275.0" y="87" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="109" fill="#001080" font-size="15">markdown</text>
+    <text x="146.0" y="109" fill="#3B3B3B" font-size="15">~</text>
+    <text x="154.6" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="109" fill="#3B3B3B" font-size="15">:</text>
+    <text x="171.8" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="109" fill="#267F99" font-size="15">String</text>
+    <text x="232.0" y="109" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#3B3B3B" font-size="15">)</text>
+    <text x="68.6" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="77.2" y="131" fill="#0000FF" font-size="15">-&gt;</text>
+    <text x="94.4" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="131" fill="#267F99" font-size="15">String</text>
+    <text x="154.6" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="131" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="153" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="153" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="153" fill="#001080" font-size="15">lines</text>
+    <text x="154.6" y="153" fill="#000000" font-size="15">:</text>
+    <text x="163.2" y="153" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="153" fill="#267F99" font-size="15">Iter</text>
+    <text x="206.2" y="153" fill="#3B3B3B" font-size="15">[</text>
+    <text x="214.8" y="153" fill="#267F99" font-size="15">StringView</text>
+    <text x="300.8" y="153" fill="#3B3B3B" font-size="15">] </text>
+    <text x="318.0" y="153" fill="#000000" font-size="15">=</text>
+    <text x="326.6" y="153" fill="#3B3B3B" font-size="15"> </text>
+    <text x="335.2" y="153" fill="#001080" font-size="15">markdown</text>
+    <text x="404.0" y="153" fill="#3B3B3B" font-size="15">.</text>
+    <text x="412.6" y="153" fill="#795E26" font-size="15">split</text>
+    <text x="455.6" y="153" fill="#3B3B3B" font-size="15">(</text>
+    <text x="464.2" y="153" fill="#A31515" font-size="15">&quot;</text>
+    <text x="472.8" y="153" fill="#EE0000" font-size="15">\n</text>
+    <text x="490.0" y="153" fill="#A31515" font-size="15">&quot;</text>
+    <text x="498.6" y="153" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="175" fill="#3B3B3B" font-size="15">(</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="197" fill="#A31515" font-size="15">$|</text>
+    <text x="111.6" y="197" fill="#A31515" font-size="15">// Generated from </text>
+    <text x="266.4" y="197" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="283.6" y="197" fill="#001080" font-size="15">base</text>
+    <text x="318.0" y="197" fill="#3B3B3B" font-size="15">}</text>
+    <text x="326.6" y="197" fill="#A31515" font-size="15"> by moon dev_build. DO NOT EDIT.</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="219" fill="#A31515" font-size="15">$|</text>
+    <text x="111.6" y="219" fill="#A31515" font-size="15">///|</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="241" fill="#A31515" font-size="15">$|</text>
+    <text x="111.6" y="241" fill="#A31515" font-size="15">fn </text>
+    <text x="137.4" y="241" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="154.6" y="241" fill="#001080" font-size="15">function_name</text>
+    <text x="266.4" y="241" fill="#3B3B3B" font-size="15">}</text>
+    <text x="275.0" y="241" fill="#A31515" font-size="15">() -&gt; String {</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="60.0" y="263" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="263" fill="#A31515" font-size="15">$|</text>
+    <text x="111.6" y="263" fill="#A31515" font-size="15">  (</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="285" fill="#A31515" font-size="15">$|</text>
+    <text x="111.6" y="285" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="128.8" y="285" fill="#001080" font-size="15">out</text>
+    <text x="154.6" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="285" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="180.4" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="285" fill="#AF00DB" font-size="15">for</text>
+    <text x="214.8" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="285" fill="#001080" font-size="15">line</text>
+    <text x="257.8" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="285" fill="#AF00DB" font-size="15">in</text>
+    <text x="283.6" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="285" fill="#001080" font-size="15">lines</text>
+    <text x="335.2" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="285" fill="#3B3B3B" font-size="15">{</text>
+    <text x="352.4" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="361.0" y="285" fill="#001080" font-size="15">out</text>
+    <text x="386.8" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="285" fill="#000000" font-size="15">&lt;</text>
+    <text x="404.0" y="285" fill="#000000" font-size="15">+</text>
+    <text x="412.6" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="421.2" y="285" fill="#001080" font-size="15">str</text>
+    <text x="447.0" y="285" fill="#A31515" font-size="15">&quot;</text>
+    <text x="455.6" y="285" fill="#A31515" font-size="15">    #|</text>
+    <text x="507.2" y="285" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="524.4" y="285" fill="#001080" font-size="15">line</text>
+    <text x="558.8" y="285" fill="#3B3B3B" font-size="15">}</text>
+    <text x="567.4" y="285" fill="#EE0000" font-size="15">\n</text>
+    <text x="584.6" y="285" fill="#A31515" font-size="15">&quot;</text>
+    <text x="593.2" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="601.8" y="285" fill="#3B3B3B" font-size="15">}</text>
+    <text x="610.4" y="285" fill="#3B3B3B" font-size="15">}</text>
+    <text x="619.0" y="285" fill="#A31515" font-size="15">  )</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="307" fill="#A31515" font-size="15">$|</text>
+    <text x="111.6" y="307" fill="#A31515" font-size="15">}</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="329" fill="#A31515" font-size="15">$|</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="60.0" y="351" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="351" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/handwritten-literals.svg
+++ b/artifacts/previews/handwritten-literals.svg
@@ -53,7 +53,13 @@
     <text x="206.2" y="131" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
     <text x="60.0" y="153" fill="#3B3B3B" font-size="15">  </text>
-    <text x="77.2" y="153" fill="#811F3F" font-size="15">re&quot;ab+\{name}&quot;</text>
+    <text x="77.2" y="153" fill="#811F3F" font-size="15">re</text>
+    <text x="94.4" y="153" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="103.0" y="153" fill="#811F3F" font-size="15">ab+</text>
+    <text x="128.8" y="153" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="146.0" y="153" fill="#001080" font-size="15">name</text>
+    <text x="180.4" y="153" fill="#3B3B3B" font-size="15">}</text>
+    <text x="189.0" y="153" fill="#811F3F" font-size="15">&quot;</text>
     <text x="197.6" y="153" fill="#3B3B3B" font-size="15"> </text>
     <text x="206.2" y="153" fill="#000000" font-size="15">|&gt;</text>
     <text x="223.4" y="153" fill="#3B3B3B" font-size="15"> </text>
@@ -64,9 +70,9 @@
     <text x="60.0" y="175" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="175" fill="#A31515" font-size="15">$|</text>
     <text x="94.4" y="175" fill="#A31515" font-size="15">hello </text>
-    <text x="146.0" y="175" fill="#A31515" font-size="15">\{</text>
+    <text x="146.0" y="175" fill="#3B3B3B" font-size="15">\{</text>
     <text x="163.2" y="175" fill="#001080" font-size="15">name</text>
-    <text x="197.6" y="175" fill="#A31515" font-size="15">}</text>
+    <text x="197.6" y="175" fill="#3B3B3B" font-size="15">}</text>
     <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
     <text x="60.0" y="197" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="197" fill="#A31515" font-size="15">#|raw line</text>

--- a/artifacts/previews/handwritten-literals.svg
+++ b/artifacts/previews/handwritten-literals.svg
@@ -62,7 +62,11 @@
     <text x="292.2" y="153" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
     <text x="60.0" y="175" fill="#3B3B3B" font-size="15">  </text>
-    <text x="77.2" y="175" fill="#A31515" font-size="15">$|hello \{name}</text>
+    <text x="77.2" y="175" fill="#A31515" font-size="15">$|</text>
+    <text x="94.4" y="175" fill="#A31515" font-size="15">hello </text>
+    <text x="146.0" y="175" fill="#A31515" font-size="15">\{</text>
+    <text x="163.2" y="175" fill="#001080" font-size="15">name</text>
+    <text x="197.6" y="175" fill="#A31515" font-size="15">}</text>
     <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
     <text x="60.0" y="197" fill="#3B3B3B" font-size="15">  </text>
     <text x="77.2" y="197" fill="#A31515" font-size="15">#|raw line</text>

--- a/artifacts/previews/handwritten-operators-comprehension.svg
+++ b/artifacts/previews/handwritten-operators-comprehension.svg
@@ -10,7 +10,7 @@
     <text x="189.0" y="43" fill="#3B3B3B" font-size="15"> </text>
     <text x="197.6" y="43" fill="#3B3B3B" font-size="15">:</text>
     <text x="206.2" y="43" fill="#3B3B3B" font-size="15"> </text>
-    <text x="214.8" y="43" fill="#0000FF" font-size="15">Array</text>
+    <text x="214.8" y="43" fill="#267F99" font-size="15">Array</text>
     <text x="257.8" y="43" fill="#3B3B3B" font-size="15">[</text>
     <text x="266.4" y="43" fill="#267F99" font-size="15">Int</text>
     <text x="292.2" y="43" fill="#3B3B3B" font-size="15">]</text>
@@ -18,7 +18,7 @@
     <text x="309.4" y="43" fill="#3B3B3B" font-size="15"> </text>
     <text x="318.0" y="43" fill="#0000FF" font-size="15">-&gt;</text>
     <text x="335.2" y="43" fill="#3B3B3B" font-size="15"> </text>
-    <text x="343.8" y="43" fill="#0000FF" font-size="15">Array</text>
+    <text x="343.8" y="43" fill="#267F99" font-size="15">Array</text>
     <text x="386.8" y="43" fill="#3B3B3B" font-size="15">[</text>
     <text x="395.4" y="43" fill="#267F99" font-size="15">Int</text>
     <text x="421.2" y="43" fill="#3B3B3B" font-size="15">]</text>

--- a/artifacts/previews/language-surface.svg
+++ b/artifacts/previews/language-surface.svg
@@ -130,9 +130,9 @@
     <text x="326.6" y="461" fill="#3B3B3B" font-size="15">(</text>
     <text x="335.2" y="461" fill="#A31515" font-size="15">&quot;</text>
     <text x="343.8" y="461" fill="#A31515" font-size="15">circle </text>
-    <text x="404.0" y="461" fill="#A31515" font-size="15">\{</text>
+    <text x="404.0" y="461" fill="#3B3B3B" font-size="15">\{</text>
     <text x="421.2" y="461" fill="#001080" font-size="15">radius</text>
-    <text x="472.8" y="461" fill="#A31515" font-size="15">}</text>
+    <text x="472.8" y="461" fill="#3B3B3B" font-size="15">}</text>
     <text x="481.4" y="461" fill="#A31515" font-size="15">&quot;</text>
     <text x="490.0" y="461" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
@@ -363,7 +363,13 @@
     <text x="576.0" y="857" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="879" fill="#6E7681" font-size="15">39</text>
     <text x="60.0" y="879" fill="#3B3B3B" font-size="15">  </text>
-    <text x="77.2" y="879" fill="#811F3F" font-size="15">re&quot;ab+\{name}&quot;</text>
+    <text x="77.2" y="879" fill="#811F3F" font-size="15">re</text>
+    <text x="94.4" y="879" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="103.0" y="879" fill="#811F3F" font-size="15">ab+</text>
+    <text x="128.8" y="879" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="146.0" y="879" fill="#001080" font-size="15">name</text>
+    <text x="180.4" y="879" fill="#3B3B3B" font-size="15">}</text>
+    <text x="189.0" y="879" fill="#811F3F" font-size="15">&quot;</text>
     <text x="197.6" y="879" fill="#3B3B3B" font-size="15"> </text>
     <text x="206.2" y="879" fill="#000000" font-size="15">|&gt;</text>
     <text x="223.4" y="879" fill="#3B3B3B" font-size="15"> </text>

--- a/artifacts/previews/language-surface.svg
+++ b/artifacts/previews/language-surface.svg
@@ -130,8 +130,9 @@
     <text x="326.6" y="461" fill="#3B3B3B" font-size="15">(</text>
     <text x="335.2" y="461" fill="#A31515" font-size="15">&quot;</text>
     <text x="343.8" y="461" fill="#A31515" font-size="15">circle </text>
-    <text x="404.0" y="461" fill="#EE0000" font-size="15">\{</text>
-    <text x="421.2" y="461" fill="#A31515" font-size="15">radius}</text>
+    <text x="404.0" y="461" fill="#A31515" font-size="15">\{</text>
+    <text x="421.2" y="461" fill="#001080" font-size="15">radius</text>
+    <text x="472.8" y="461" fill="#A31515" font-size="15">}</text>
     <text x="481.4" y="461" fill="#A31515" font-size="15">&quot;</text>
     <text x="490.0" y="461" fill="#3B3B3B" font-size="15">)</text>
     <text x="26" y="483" fill="#6E7681" font-size="15">21</text>

--- a/artifacts/previews/list-spread-pattern.svg
+++ b/artifacts/previews/list-spread-pattern.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="258" height="232" viewBox="0 0 258 232">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#0000FF" font-size="15">test</text>
+    <text x="94.4" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="43" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="65" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="65" fill="#001080" font-size="15">xs</text>
+    <text x="128.8" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="137.4" y="65" fill="#000000" font-size="15">=</text>
+    <text x="146.0" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="65" fill="#3B3B3B" font-size="15">[</text>
+    <text x="163.2" y="65" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="87" fill="#AF00DB" font-size="15">match</text>
+    <text x="120.2" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="87" fill="#001080" font-size="15">xs</text>
+    <text x="146.0" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="87" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="109" fill="#3B3B3B" font-size="15">[</text>
+    <text x="103.0" y="109" fill="#3B3B3B" font-size="15">]</text>
+    <text x="111.6" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="120.2" y="109" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="137.4" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="109" fill="#3B3B3B" font-size="15">(</text>
+    <text x="154.6" y="109" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#3B3B3B" font-size="15">    </text>
+    <text x="94.4" y="131" fill="#3B3B3B" font-size="15">[</text>
+    <text x="103.0" y="131" fill="#001080" font-size="15">x</text>
+    <text x="111.6" y="131" fill="#3B3B3B" font-size="15">,</text>
+    <text x="120.2" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="131" fill="#000000" font-size="15">..</text>
+    <text x="146.0" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="131" fill="#001080" font-size="15">xs</text>
+    <text x="171.8" y="131" fill="#3B3B3B" font-size="15">]</text>
+    <text x="180.4" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="131" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="206.2" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="214.8" y="131" fill="#3B3B3B" font-size="15">(</text>
+    <text x="223.4" y="131" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="153" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="60.0" y="175" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="175" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="175" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="175" fill="#001080" font-size="15">ys</text>
+    <text x="128.8" y="175" fill="#3B3B3B" font-size="15"> </text>
+    <text x="137.4" y="175" fill="#000000" font-size="15">=</text>
+    <text x="146.0" y="175" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="175" fill="#3B3B3B" font-size="15">[</text>
+    <text x="163.2" y="175" fill="#000000" font-size="15">..</text>
+    <text x="180.4" y="175" fill="#001080" font-size="15">xs</text>
+    <text x="197.6" y="175" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/official-parser-regressions.svg
+++ b/artifacts/previews/official-parser-regressions.svg
@@ -250,7 +250,10 @@
     <text x="223.4" y="703" fill="#3B3B3B" font-size="15"> </text>
     <text x="232.0" y="703" fill="#000000" font-size="15">=</text>
     <text x="240.6" y="703" fill="#3B3B3B" font-size="15"> </text>
-    <text x="249.2" y="703" fill="#811F3F" font-size="15">re&quot;/\*&quot;</text>
+    <text x="249.2" y="703" fill="#811F3F" font-size="15">re</text>
+    <text x="266.4" y="703" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="275.0" y="703" fill="#811F3F" font-size="15">/\*</text>
+    <text x="300.8" y="703" fill="#811F3F" font-size="15">&quot;</text>
     <text x="26" y="725" fill="#6E7681" font-size="15">32</text>
     <text x="60.0" y="725" fill="#0000FF" font-size="15">const</text>
     <text x="103.0" y="725" fill="#3B3B3B" font-size="15"> </text>
@@ -258,7 +261,11 @@
     <text x="206.2" y="725" fill="#3B3B3B" font-size="15"> </text>
     <text x="214.8" y="725" fill="#000000" font-size="15">=</text>
     <text x="223.4" y="725" fill="#3B3B3B" font-size="15"> </text>
-    <text x="232.0" y="725" fill="#811F3F" font-size="15">re&quot;\*/&quot;</text>
+    <text x="232.0" y="725" fill="#811F3F" font-size="15">re</text>
+    <text x="249.2" y="725" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="257.8" y="725" fill="#EE0000" font-size="15">\*</text>
+    <text x="275.0" y="725" fill="#811F3F" font-size="15">/</text>
+    <text x="283.6" y="725" fill="#811F3F" font-size="15">&quot;</text>
     <text x="26" y="747" fill="#6E7681" font-size="15">33</text>
     <text x="60.0" y="747" fill="#0000FF" font-size="15">const</text>
     <text x="103.0" y="747" fill="#3B3B3B" font-size="15"> </text>
@@ -266,7 +273,10 @@
     <text x="189.0" y="747" fill="#3B3B3B" font-size="15"> </text>
     <text x="197.6" y="747" fill="#000000" font-size="15">=</text>
     <text x="206.2" y="747" fill="#3B3B3B" font-size="15"> </text>
-    <text x="214.8" y="747" fill="#811F3F" font-size="15">re&quot;[ \t]*&quot;</text>
+    <text x="214.8" y="747" fill="#811F3F" font-size="15">re</text>
+    <text x="232.0" y="747" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="240.6" y="747" fill="#811F3F" font-size="15">[ \t]*</text>
+    <text x="292.2" y="747" fill="#811F3F" font-size="15">&quot;</text>
     <text x="26" y="769" fill="#6E7681" font-size="15">34</text>
     <text x="60.0" y="769" fill="#0000FF" font-size="15">const</text>
     <text x="103.0" y="769" fill="#3B3B3B" font-size="15"> </text>
@@ -274,7 +284,10 @@
     <text x="137.4" y="769" fill="#3B3B3B" font-size="15"> </text>
     <text x="146.0" y="769" fill="#000000" font-size="15">=</text>
     <text x="154.6" y="769" fill="#3B3B3B" font-size="15"> </text>
-    <text x="163.2" y="769" fill="#811F3F" font-size="15">re&quot;b&quot;</text>
+    <text x="163.2" y="769" fill="#811F3F" font-size="15">re</text>
+    <text x="180.4" y="769" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="189.0" y="769" fill="#811F3F" font-size="15">b</text>
+    <text x="197.6" y="769" fill="#811F3F" font-size="15">&quot;</text>
     <text x="26" y="791" fill="#6E7681" font-size="15">35</text>
     <text x="60.0" y="791" fill="#0000FF" font-size="15">const</text>
     <text x="103.0" y="791" fill="#3B3B3B" font-size="15"> </text>
@@ -282,7 +295,10 @@
     <text x="163.2" y="791" fill="#3B3B3B" font-size="15"> </text>
     <text x="171.8" y="791" fill="#000000" font-size="15">=</text>
     <text x="180.4" y="791" fill="#3B3B3B" font-size="15"> </text>
-    <text x="189.0" y="791" fill="#811F3F" font-size="15">re&quot;bc&quot;</text>
+    <text x="189.0" y="791" fill="#811F3F" font-size="15">re</text>
+    <text x="206.2" y="791" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="214.8" y="791" fill="#811F3F" font-size="15">bc</text>
+    <text x="232.0" y="791" fill="#811F3F" font-size="15">&quot;</text>
     <text x="26" y="813" fill="#6E7681" font-size="15">36</text>
     <text x="26" y="835" fill="#6E7681" font-size="15">37</text>
     <text x="60.0" y="835" fill="#0000FF" font-size="15">fn</text>
@@ -352,7 +368,7 @@
     <text x="352.4" y="945" fill="#3B3B3B" font-size="15"> </text>
     <text x="361.0" y="945" fill="#000000" font-size="15">:</text>
     <text x="369.6" y="945" fill="#3B3B3B" font-size="15"> </text>
-    <text x="378.2" y="945" fill="#0000FF" font-size="15">Array</text>
+    <text x="378.2" y="945" fill="#267F99" font-size="15">Array</text>
     <text x="421.2" y="945" fill="#3B3B3B" font-size="15">[</text>
     <text x="429.8" y="945" fill="#267F99" font-size="15">Int</text>
     <text x="455.6" y="945" fill="#3B3B3B" font-size="15">]</text>
@@ -515,7 +531,10 @@
     <text x="335.2" y="1187" fill="#267F99" font-size="15">BLANK_OPT</text>
     <text x="412.6" y="1187" fill="#3B3B3B" font-size="15"> </text>
     <text x="421.2" y="1187" fill="#3B3B3B" font-size="15">(</text>
-    <text x="429.8" y="1187" fill="#811F3F" font-size="15">re&quot;.*?&quot;</text>
+    <text x="429.8" y="1187" fill="#811F3F" font-size="15">re</text>
+    <text x="447.0" y="1187" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="455.6" y="1187" fill="#811F3F" font-size="15">.*?</text>
+    <text x="481.4" y="1187" fill="#811F3F" font-size="15">&quot;</text>
     <text x="490.0" y="1187" fill="#3B3B3B" font-size="15"> </text>
     <text x="498.6" y="1187" fill="#0000FF" font-size="15">as</text>
     <text x="515.8" y="1187" fill="#3B3B3B" font-size="15"> </text>
@@ -551,7 +570,10 @@
     <text x="180.4" y="1275" fill="#3B3B3B" font-size="15"> </text>
     <text x="189.0" y="1275" fill="#3B3B3B" font-size="15">(</text>
     <text x="197.6" y="1275" fill="#3B3B3B" font-size="15">(</text>
-    <text x="206.2" y="1275" fill="#811F3F" font-size="15">re&quot;x&quot;</text>
+    <text x="206.2" y="1275" fill="#811F3F" font-size="15">re</text>
+    <text x="223.4" y="1275" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="232.0" y="1275" fill="#811F3F" font-size="15">x</text>
+    <text x="240.6" y="1275" fill="#811F3F" font-size="15">&quot;</text>
     <text x="249.2" y="1275" fill="#3B3B3B" font-size="15"> </text>
     <text x="257.8" y="1275" fill="#000000" font-size="15">|</text>
     <text x="266.4" y="1275" fill="#3B3B3B" font-size="15"> </text>

--- a/artifacts/previews/proof-surface.svg
+++ b/artifacts/previews/proof-surface.svg
@@ -11,7 +11,7 @@
     <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
     <text x="60.0" y="65" fill="#0000FF" font-size="15">fn</text>
     <text x="77.2" y="65" fill="#3B3B3B" font-size="15"> </text>
-    <text x="85.8" y="65" fill="#795E26" font-size="15">MathInt</text>
+    <text x="85.8" y="65" fill="#267F99" font-size="15">MathInt</text>
     <text x="146.0" y="65" fill="#3B3B3B" font-size="15">:</text>
     <text x="154.6" y="65" fill="#3B3B3B" font-size="15">:</text>
     <text x="163.2" y="65" fill="#795E26" font-size="15">equal</text>
@@ -78,7 +78,7 @@
     <text x="85.8" y="197" fill="#3B3B3B" font-size="15"> </text>
     <text x="94.4" y="197" fill="#0000FF" font-size="15">predicate</text>
     <text x="171.8" y="197" fill="#3B3B3B" font-size="15"> </text>
-    <text x="180.4" y="197" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="180.4" y="197" fill="#267F99" font-size="15">FixedArray</text>
     <text x="266.4" y="197" fill="#3B3B3B" font-size="15">:</text>
     <text x="275.0" y="197" fill="#3B3B3B" font-size="15">:</text>
     <text x="283.6" y="197" fill="#795E26" font-size="15">in_bounds</text>
@@ -87,7 +87,7 @@
     <text x="404.0" y="197" fill="#3B3B3B" font-size="15"> </text>
     <text x="412.6" y="197" fill="#3B3B3B" font-size="15">:</text>
     <text x="421.2" y="197" fill="#3B3B3B" font-size="15"> </text>
-    <text x="429.8" y="197" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="429.8" y="197" fill="#267F99" font-size="15">FixedArray</text>
     <text x="515.8" y="197" fill="#3B3B3B" font-size="15">[</text>
     <text x="524.4" y="197" fill="#267F99" font-size="15">Int</text>
     <text x="550.2" y="197" fill="#3B3B3B" font-size="15">]</text>
@@ -138,7 +138,7 @@
     <text x="257.8" y="285" fill="#3B3B3B" font-size="15"> </text>
     <text x="266.4" y="285" fill="#3B3B3B" font-size="15">:</text>
     <text x="275.0" y="285" fill="#3B3B3B" font-size="15"> </text>
-    <text x="283.6" y="285" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="283.6" y="285" fill="#267F99" font-size="15">FixedArray</text>
     <text x="369.6" y="285" fill="#3B3B3B" font-size="15">[</text>
     <text x="378.2" y="285" fill="#267F99" font-size="15">Int</text>
     <text x="404.0" y="285" fill="#3B3B3B" font-size="15">]</text>
@@ -165,7 +165,7 @@
     <text x="223.4" y="307" fill="#267F99" font-size="15">Int</text>
     <text x="249.2" y="307" fill="#3B3B3B" font-size="15">,</text>
     <text x="257.8" y="307" fill="#3B3B3B" font-size="15"> </text>
-    <text x="266.4" y="307" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="266.4" y="307" fill="#267F99" font-size="15">FixedArray</text>
     <text x="352.4" y="307" fill="#3B3B3B" font-size="15">:</text>
     <text x="361.0" y="307" fill="#3B3B3B" font-size="15">:</text>
     <text x="369.6" y="307" fill="#795E26" font-size="15">in_bounds</text>
@@ -195,7 +195,7 @@
     <text x="154.6" y="373" fill="#3B3B3B" font-size="15"> </text>
     <text x="163.2" y="373" fill="#3B3B3B" font-size="15">:</text>
     <text x="171.8" y="373" fill="#3B3B3B" font-size="15"> </text>
-    <text x="180.4" y="373" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="180.4" y="373" fill="#267F99" font-size="15">FixedArray</text>
     <text x="266.4" y="373" fill="#3B3B3B" font-size="15">[</text>
     <text x="275.0" y="373" fill="#267F99" font-size="15">Int</text>
     <text x="300.8" y="373" fill="#3B3B3B" font-size="15">]</text>
@@ -227,7 +227,7 @@
     <text x="249.2" y="417" fill="#3B3B3B" font-size="15"> </text>
     <text x="257.8" y="417" fill="#0000FF" font-size="15">=&gt;</text>
     <text x="275.0" y="417" fill="#3B3B3B" font-size="15"> </text>
-    <text x="283.6" y="417" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="283.6" y="417" fill="#267F99" font-size="15">FixedArray</text>
     <text x="369.6" y="417" fill="#3B3B3B" font-size="15">:</text>
     <text x="378.2" y="417" fill="#3B3B3B" font-size="15">:</text>
     <text x="386.8" y="417" fill="#795E26" font-size="15">in_bounds</text>
@@ -255,7 +255,7 @@
     <text x="240.6" y="461" fill="#267F99" font-size="15">Int</text>
     <text x="266.4" y="461" fill="#3B3B3B" font-size="15">,</text>
     <text x="275.0" y="461" fill="#3B3B3B" font-size="15"> </text>
-    <text x="283.6" y="461" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="283.6" y="461" fill="#267F99" font-size="15">FixedArray</text>
     <text x="369.6" y="461" fill="#3B3B3B" font-size="15">:</text>
     <text x="378.2" y="461" fill="#3B3B3B" font-size="15">:</text>
     <text x="386.8" y="461" fill="#795E26" font-size="15">in_bounds</text>
@@ -283,7 +283,7 @@
     <text x="266.4" y="549" fill="#3B3B3B" font-size="15"> </text>
     <text x="275.0" y="549" fill="#3B3B3B" font-size="15">:</text>
     <text x="283.6" y="549" fill="#3B3B3B" font-size="15"> </text>
-    <text x="292.2" y="549" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="292.2" y="549" fill="#267F99" font-size="15">FixedArray</text>
     <text x="378.2" y="549" fill="#3B3B3B" font-size="15">[</text>
     <text x="386.8" y="549" fill="#267F99" font-size="15">Int</text>
     <text x="412.6" y="549" fill="#3B3B3B" font-size="15">]</text>
@@ -307,7 +307,7 @@
     <text x="77.2" y="593" fill="#0000FF" font-size="15">proof_ensure</text>
     <text x="180.4" y="593" fill="#3B3B3B" font-size="15">:</text>
     <text x="189.0" y="593" fill="#3B3B3B" font-size="15"> </text>
-    <text x="197.6" y="593" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="197.6" y="593" fill="#267F99" font-size="15">FixedArray</text>
     <text x="283.6" y="593" fill="#3B3B3B" font-size="15">:</text>
     <text x="292.2" y="593" fill="#3B3B3B" font-size="15">:</text>
     <text x="300.8" y="593" fill="#795E26" font-size="15">in_bounds</text>

--- a/artifacts/previews/proof-surface.svg
+++ b/artifacts/previews/proof-surface.svg
@@ -1,0 +1,346 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="688" height="716" viewBox="0 0 688 716">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#795E26" font-size="15">#proof_import</text>
+    <text x="171.8" y="43" fill="#3B3B3B" font-size="15">(</text>
+    <text x="180.4" y="43" fill="#A31515" font-size="15">&quot;</text>
+    <text x="189.0" y="43" fill="#A31515" font-size="15">int.Int</text>
+    <text x="249.2" y="43" fill="#A31515" font-size="15">&quot;</text>
+    <text x="257.8" y="43" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#0000FF" font-size="15">fn</text>
+    <text x="77.2" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="85.8" y="65" fill="#795E26" font-size="15">MathInt</text>
+    <text x="146.0" y="65" fill="#3B3B3B" font-size="15">:</text>
+    <text x="154.6" y="65" fill="#3B3B3B" font-size="15">:</text>
+    <text x="163.2" y="65" fill="#795E26" font-size="15">equal</text>
+    <text x="206.2" y="65" fill="#3B3B3B" font-size="15">(</text>
+    <text x="214.8" y="65" fill="#001080" font-size="15">self</text>
+    <text x="249.2" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="65" fill="#3B3B3B" font-size="15">:</text>
+    <text x="266.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="65" fill="#267F99" font-size="15">MathInt</text>
+    <text x="335.2" y="65" fill="#3B3B3B" font-size="15">,</text>
+    <text x="343.8" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="352.4" y="65" fill="#001080" font-size="15">other</text>
+    <text x="395.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="404.0" y="65" fill="#3B3B3B" font-size="15">:</text>
+    <text x="412.6" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="421.2" y="65" fill="#267F99" font-size="15">MathInt</text>
+    <text x="481.4" y="65" fill="#3B3B3B" font-size="15">)</text>
+    <text x="490.0" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="498.6" y="65" fill="#0000FF" font-size="15">-&gt;</text>
+    <text x="515.8" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="524.4" y="65" fill="#267F99" font-size="15">Bool</text>
+    <text x="558.8" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="567.4" y="65" fill="#000000" font-size="15">=</text>
+    <text x="576.0" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="584.6" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="593.2" y="65" fill="#A31515" font-size="15">(=)</text>
+    <text x="619.0" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#0000FF" font-size="15">pub</text>
+    <text x="85.8" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="94.4" y="109" fill="#0000FF" font-size="15">impl</text>
+    <text x="128.8" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="137.4" y="109" fill="#267F99" font-size="15">Eq</text>
+    <text x="154.6" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="109" fill="#0000FF" font-size="15">for</text>
+    <text x="189.0" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="109" fill="#267F99" font-size="15">MathInt</text>
+    <text x="257.8" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="109" fill="#0000FF" font-size="15">with</text>
+    <text x="300.8" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="109" fill="#795E26" font-size="15">equal</text>
+    <text x="352.4" y="109" fill="#3B3B3B" font-size="15">(</text>
+    <text x="361.0" y="109" fill="#001080" font-size="15">self</text>
+    <text x="395.4" y="109" fill="#3B3B3B" font-size="15">,</text>
+    <text x="404.0" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="412.6" y="109" fill="#001080" font-size="15">other</text>
+    <text x="455.6" y="109" fill="#3B3B3B" font-size="15">)</text>
+    <text x="464.2" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="472.8" y="109" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="131" fill="#001080" font-size="15">self</text>
+    <text x="111.6" y="131" fill="#3B3B3B" font-size="15">.</text>
+    <text x="120.2" y="131" fill="#795E26" font-size="15">equal</text>
+    <text x="163.2" y="131" fill="#3B3B3B" font-size="15">(</text>
+    <text x="171.8" y="131" fill="#001080" font-size="15">other</text>
+    <text x="214.8" y="131" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="175" fill="#6E7681" font-size="15"> 7</text>
+    <text x="26" y="197" fill="#6E7681" font-size="15"> 8</text>
+    <text x="60.0" y="197" fill="#0000FF" font-size="15">pub</text>
+    <text x="85.8" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="94.4" y="197" fill="#0000FF" font-size="15">predicate</text>
+    <text x="171.8" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="197" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="266.4" y="197" fill="#3B3B3B" font-size="15">:</text>
+    <text x="275.0" y="197" fill="#3B3B3B" font-size="15">:</text>
+    <text x="283.6" y="197" fill="#795E26" font-size="15">in_bounds</text>
+    <text x="361.0" y="197" fill="#3B3B3B" font-size="15">(</text>
+    <text x="369.6" y="197" fill="#001080" font-size="15">self</text>
+    <text x="404.0" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="412.6" y="197" fill="#3B3B3B" font-size="15">:</text>
+    <text x="421.2" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="429.8" y="197" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="515.8" y="197" fill="#3B3B3B" font-size="15">[</text>
+    <text x="524.4" y="197" fill="#267F99" font-size="15">Int</text>
+    <text x="550.2" y="197" fill="#3B3B3B" font-size="15">]</text>
+    <text x="558.8" y="197" fill="#3B3B3B" font-size="15">,</text>
+    <text x="567.4" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="576.0" y="197" fill="#001080" font-size="15">i</text>
+    <text x="584.6" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="593.2" y="197" fill="#3B3B3B" font-size="15">:</text>
+    <text x="601.8" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="610.4" y="197" fill="#267F99" font-size="15">Int</text>
+    <text x="636.2" y="197" fill="#3B3B3B" font-size="15">)</text>
+    <text x="644.8" y="197" fill="#3B3B3B" font-size="15"> </text>
+    <text x="653.4" y="197" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="219" fill="#6E7681" font-size="15"> 9</text>
+    <text x="60.0" y="219" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="219" fill="#3B3B3B" font-size="15">(</text>
+    <text x="85.8" y="219" fill="#098658" font-size="15">0</text>
+    <text x="94.4" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="103.0" y="219" fill="#000000" font-size="15">&lt;=</text>
+    <text x="120.2" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="219" fill="#001080" font-size="15">i</text>
+    <text x="137.4" y="219" fill="#3B3B3B" font-size="15">)</text>
+    <text x="146.0" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="154.6" y="219" fill="#000000" font-size="15">&amp;&amp;</text>
+    <text x="171.8" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="219" fill="#3B3B3B" font-size="15">(</text>
+    <text x="189.0" y="219" fill="#001080" font-size="15">i</text>
+    <text x="197.6" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="219" fill="#000000" font-size="15">&lt;</text>
+    <text x="214.8" y="219" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="219" fill="#001080" font-size="15">self</text>
+    <text x="257.8" y="219" fill="#3B3B3B" font-size="15">.</text>
+    <text x="266.4" y="219" fill="#795E26" font-size="15">length</text>
+    <text x="318.0" y="219" fill="#3B3B3B" font-size="15">(</text>
+    <text x="326.6" y="219" fill="#3B3B3B" font-size="15">)</text>
+    <text x="335.2" y="219" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="241" fill="#6E7681" font-size="15">10</text>
+    <text x="60.0" y="241" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="263" fill="#6E7681" font-size="15">11</text>
+    <text x="26" y="285" fill="#6E7681" font-size="15">12</text>
+    <text x="60.0" y="285" fill="#0000FF" font-size="15">pub</text>
+    <text x="85.8" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="94.4" y="285" fill="#0000FF" font-size="15">predicate</text>
+    <text x="171.8" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="285" fill="#795E26" font-size="15">sorted</text>
+    <text x="232.0" y="285" fill="#3B3B3B" font-size="15">(</text>
+    <text x="240.6" y="285" fill="#001080" font-size="15">xs</text>
+    <text x="257.8" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="285" fill="#3B3B3B" font-size="15">:</text>
+    <text x="275.0" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="285" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="369.6" y="285" fill="#3B3B3B" font-size="15">[</text>
+    <text x="378.2" y="285" fill="#267F99" font-size="15">Int</text>
+    <text x="404.0" y="285" fill="#3B3B3B" font-size="15">]</text>
+    <text x="412.6" y="285" fill="#3B3B3B" font-size="15">)</text>
+    <text x="421.2" y="285" fill="#3B3B3B" font-size="15"> </text>
+    <text x="429.8" y="285" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="307" fill="#6E7681" font-size="15">13</text>
+    <text x="60.0" y="307" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="307" fill="#000000" font-size="15">∀</text>
+    <text x="85.8" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="94.4" y="307" fill="#001080" font-size="15">i</text>
+    <text x="103.0" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="307" fill="#3B3B3B" font-size="15">:</text>
+    <text x="120.2" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="307" fill="#267F99" font-size="15">Int</text>
+    <text x="154.6" y="307" fill="#3B3B3B" font-size="15">,</text>
+    <text x="163.2" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="171.8" y="307" fill="#000000" font-size="15">∃</text>
+    <text x="180.4" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="307" fill="#001080" font-size="15">j</text>
+    <text x="197.6" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="307" fill="#3B3B3B" font-size="15">:</text>
+    <text x="214.8" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="307" fill="#267F99" font-size="15">Int</text>
+    <text x="249.2" y="307" fill="#3B3B3B" font-size="15">,</text>
+    <text x="257.8" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="266.4" y="307" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="352.4" y="307" fill="#3B3B3B" font-size="15">:</text>
+    <text x="361.0" y="307" fill="#3B3B3B" font-size="15">:</text>
+    <text x="369.6" y="307" fill="#795E26" font-size="15">in_bounds</text>
+    <text x="447.0" y="307" fill="#3B3B3B" font-size="15">(</text>
+    <text x="455.6" y="307" fill="#001080" font-size="15">xs</text>
+    <text x="472.8" y="307" fill="#3B3B3B" font-size="15">,</text>
+    <text x="481.4" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="490.0" y="307" fill="#001080" font-size="15">i</text>
+    <text x="498.6" y="307" fill="#3B3B3B" font-size="15">)</text>
+    <text x="507.2" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="515.8" y="307" fill="#000000" font-size="15">→</text>
+    <text x="524.4" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="533.0" y="307" fill="#001080" font-size="15">i</text>
+    <text x="541.6" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="550.2" y="307" fill="#000000" font-size="15">&lt;=</text>
+    <text x="567.4" y="307" fill="#3B3B3B" font-size="15"> </text>
+    <text x="576.0" y="307" fill="#001080" font-size="15">j</text>
+    <text x="26" y="329" fill="#6E7681" font-size="15">14</text>
+    <text x="60.0" y="329" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="351" fill="#6E7681" font-size="15">15</text>
+    <text x="26" y="373" fill="#6E7681" font-size="15">16</text>
+    <text x="60.0" y="373" fill="#0000FF" font-size="15">fn</text>
+    <text x="77.2" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="85.8" y="373" fill="#795E26" font-size="15">first</text>
+    <text x="128.8" y="373" fill="#3B3B3B" font-size="15">(</text>
+    <text x="137.4" y="373" fill="#001080" font-size="15">xs</text>
+    <text x="154.6" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="373" fill="#3B3B3B" font-size="15">:</text>
+    <text x="171.8" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="373" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="266.4" y="373" fill="#3B3B3B" font-size="15">[</text>
+    <text x="275.0" y="373" fill="#267F99" font-size="15">Int</text>
+    <text x="300.8" y="373" fill="#3B3B3B" font-size="15">]</text>
+    <text x="309.4" y="373" fill="#3B3B3B" font-size="15">)</text>
+    <text x="318.0" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="326.6" y="373" fill="#0000FF" font-size="15">-&gt;</text>
+    <text x="343.8" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="352.4" y="373" fill="#267F99" font-size="15">Int</text>
+    <text x="378.2" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="386.8" y="373" fill="#0000FF" font-size="15">where</text>
+    <text x="429.8" y="373" fill="#3B3B3B" font-size="15"> </text>
+    <text x="438.4" y="373" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="395" fill="#6E7681" font-size="15">17</text>
+    <text x="60.0" y="395" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="395" fill="#0000FF" font-size="15">proof_require</text>
+    <text x="189.0" y="395" fill="#3B3B3B" font-size="15">:</text>
+    <text x="197.6" y="395" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="395" fill="#795E26" font-size="15">sorted</text>
+    <text x="257.8" y="395" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="395" fill="#001080" font-size="15">xs</text>
+    <text x="283.6" y="395" fill="#3B3B3B" font-size="15">)</text>
+    <text x="292.2" y="395" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="417" fill="#6E7681" font-size="15">18</text>
+    <text x="60.0" y="417" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="417" fill="#0000FF" font-size="15">proof_ensure</text>
+    <text x="180.4" y="417" fill="#3B3B3B" font-size="15">:</text>
+    <text x="189.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="417" fill="#001080" font-size="15">result</text>
+    <text x="249.2" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="257.8" y="417" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="275.0" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="417" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="369.6" y="417" fill="#3B3B3B" font-size="15">:</text>
+    <text x="378.2" y="417" fill="#3B3B3B" font-size="15">:</text>
+    <text x="386.8" y="417" fill="#795E26" font-size="15">in_bounds</text>
+    <text x="464.2" y="417" fill="#3B3B3B" font-size="15">(</text>
+    <text x="472.8" y="417" fill="#001080" font-size="15">xs</text>
+    <text x="490.0" y="417" fill="#3B3B3B" font-size="15">,</text>
+    <text x="498.6" y="417" fill="#3B3B3B" font-size="15"> </text>
+    <text x="507.2" y="417" fill="#001080" font-size="15">result</text>
+    <text x="558.8" y="417" fill="#3B3B3B" font-size="15">)</text>
+    <text x="567.4" y="417" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="439" fill="#6E7681" font-size="15">19</text>
+    <text x="60.0" y="439" fill="#3B3B3B" font-size="15">}</text>
+    <text x="68.6" y="439" fill="#3B3B3B" font-size="15"> </text>
+    <text x="77.2" y="439" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="461" fill="#6E7681" font-size="15">20</text>
+    <text x="60.0" y="461" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="461" fill="#AF00DB" font-size="15">proof_assert</text>
+    <text x="180.4" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="461" fill="#000000" font-size="15">∃</text>
+    <text x="197.6" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="461" fill="#001080" font-size="15">i</text>
+    <text x="214.8" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="223.4" y="461" fill="#3B3B3B" font-size="15">:</text>
+    <text x="232.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="240.6" y="461" fill="#267F99" font-size="15">Int</text>
+    <text x="266.4" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="275.0" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="283.6" y="461" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="369.6" y="461" fill="#3B3B3B" font-size="15">:</text>
+    <text x="378.2" y="461" fill="#3B3B3B" font-size="15">:</text>
+    <text x="386.8" y="461" fill="#795E26" font-size="15">in_bounds</text>
+    <text x="464.2" y="461" fill="#3B3B3B" font-size="15">(</text>
+    <text x="472.8" y="461" fill="#001080" font-size="15">xs</text>
+    <text x="490.0" y="461" fill="#3B3B3B" font-size="15">,</text>
+    <text x="498.6" y="461" fill="#3B3B3B" font-size="15"> </text>
+    <text x="507.2" y="461" fill="#001080" font-size="15">i</text>
+    <text x="515.8" y="461" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="483" fill="#6E7681" font-size="15">21</text>
+    <text x="60.0" y="483" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="483" fill="#001080" font-size="15">xs</text>
+    <text x="94.4" y="483" fill="#3B3B3B" font-size="15">[</text>
+    <text x="103.0" y="483" fill="#098658" font-size="15">0</text>
+    <text x="111.6" y="483" fill="#3B3B3B" font-size="15">]</text>
+    <text x="26" y="505" fill="#6E7681" font-size="15">22</text>
+    <text x="60.0" y="505" fill="#3B3B3B" font-size="15">}</text>
+    <text x="26" y="527" fill="#6E7681" font-size="15">23</text>
+    <text x="26" y="549" fill="#6E7681" font-size="15">24</text>
+    <text x="60.0" y="549" fill="#0000FF" font-size="15">lemma</text>
+    <text x="103.0" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="549" fill="#795E26" font-size="15">first_in_bounds</text>
+    <text x="240.6" y="549" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="549" fill="#001080" font-size="15">xs</text>
+    <text x="266.4" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="549" fill="#3B3B3B" font-size="15">:</text>
+    <text x="283.6" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="292.2" y="549" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="378.2" y="549" fill="#3B3B3B" font-size="15">[</text>
+    <text x="386.8" y="549" fill="#267F99" font-size="15">Int</text>
+    <text x="412.6" y="549" fill="#3B3B3B" font-size="15">]</text>
+    <text x="421.2" y="549" fill="#3B3B3B" font-size="15">)</text>
+    <text x="429.8" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="438.4" y="549" fill="#0000FF" font-size="15">where</text>
+    <text x="481.4" y="549" fill="#3B3B3B" font-size="15"> </text>
+    <text x="490.0" y="549" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="571" fill="#6E7681" font-size="15">25</text>
+    <text x="60.0" y="571" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="571" fill="#0000FF" font-size="15">proof_require</text>
+    <text x="189.0" y="571" fill="#3B3B3B" font-size="15">:</text>
+    <text x="197.6" y="571" fill="#3B3B3B" font-size="15"> </text>
+    <text x="206.2" y="571" fill="#795E26" font-size="15">sorted</text>
+    <text x="257.8" y="571" fill="#3B3B3B" font-size="15">(</text>
+    <text x="266.4" y="571" fill="#001080" font-size="15">xs</text>
+    <text x="283.6" y="571" fill="#3B3B3B" font-size="15">)</text>
+    <text x="292.2" y="571" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="593" fill="#6E7681" font-size="15">26</text>
+    <text x="60.0" y="593" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="593" fill="#0000FF" font-size="15">proof_ensure</text>
+    <text x="180.4" y="593" fill="#3B3B3B" font-size="15">:</text>
+    <text x="189.0" y="593" fill="#3B3B3B" font-size="15"> </text>
+    <text x="197.6" y="593" fill="#0000FF" font-size="15">FixedArray</text>
+    <text x="283.6" y="593" fill="#3B3B3B" font-size="15">:</text>
+    <text x="292.2" y="593" fill="#3B3B3B" font-size="15">:</text>
+    <text x="300.8" y="593" fill="#795E26" font-size="15">in_bounds</text>
+    <text x="378.2" y="593" fill="#3B3B3B" font-size="15">(</text>
+    <text x="386.8" y="593" fill="#001080" font-size="15">xs</text>
+    <text x="404.0" y="593" fill="#3B3B3B" font-size="15">,</text>
+    <text x="412.6" y="593" fill="#3B3B3B" font-size="15"> </text>
+    <text x="421.2" y="593" fill="#795E26" font-size="15">first</text>
+    <text x="464.2" y="593" fill="#3B3B3B" font-size="15">(</text>
+    <text x="472.8" y="593" fill="#001080" font-size="15">xs</text>
+    <text x="490.0" y="593" fill="#3B3B3B" font-size="15">)</text>
+    <text x="498.6" y="593" fill="#3B3B3B" font-size="15">)</text>
+    <text x="507.2" y="593" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="615" fill="#6E7681" font-size="15">27</text>
+    <text x="60.0" y="615" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="615" fill="#0000FF" font-size="15">proof_decrease</text>
+    <text x="197.6" y="615" fill="#3B3B3B" font-size="15">:</text>
+    <text x="206.2" y="615" fill="#3B3B3B" font-size="15"> </text>
+    <text x="214.8" y="615" fill="#001080" font-size="15">xs</text>
+    <text x="232.0" y="615" fill="#3B3B3B" font-size="15">,</text>
+    <text x="26" y="637" fill="#6E7681" font-size="15">28</text>
+    <text x="60.0" y="637" fill="#3B3B3B" font-size="15">}</text>
+    <text x="68.6" y="637" fill="#3B3B3B" font-size="15"> </text>
+    <text x="77.2" y="637" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="659" fill="#6E7681" font-size="15">29</text>
+    <text x="60.0" y="659" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="659" fill="#AF00DB" font-size="15">proof_assert</text>
+    <text x="180.4" y="659" fill="#3B3B3B" font-size="15"> </text>
+    <text x="189.0" y="659" fill="#795E26" font-size="15">sorted</text>
+    <text x="240.6" y="659" fill="#3B3B3B" font-size="15">(</text>
+    <text x="249.2" y="659" fill="#001080" font-size="15">xs</text>
+    <text x="266.4" y="659" fill="#3B3B3B" font-size="15">)</text>
+    <text x="26" y="681" fill="#6E7681" font-size="15">30</text>
+    <text x="60.0" y="681" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/artifacts/previews/string-interpolation.svg
+++ b/artifacts/previews/string-interpolation.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="783" height="188" viewBox="0 0 783 188">
+  <rect width="100%" height="100%" rx="8" fill="#FFFFFF"/>
+  <g font-family="SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" xml:space="preserve">
+    <text x="26" y="43" fill="#6E7681" font-size="15"> 1</text>
+    <text x="60.0" y="43" fill="#0000FF" font-size="15">fn</text>
+    <text x="77.2" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="85.8" y="43" fill="#795E26" font-size="15">complex_string_interpolation</text>
+    <text x="326.6" y="43" fill="#3B3B3B" font-size="15">(</text>
+    <text x="335.2" y="43" fill="#001080" font-size="15">value</text>
+    <text x="378.2" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="386.8" y="43" fill="#3B3B3B" font-size="15">:</text>
+    <text x="395.4" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="404.0" y="43" fill="#267F99" font-size="15">Int</text>
+    <text x="429.8" y="43" fill="#3B3B3B" font-size="15">,</text>
+    <text x="438.4" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="447.0" y="43" fill="#001080" font-size="15">name</text>
+    <text x="481.4" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="490.0" y="43" fill="#3B3B3B" font-size="15">:</text>
+    <text x="498.6" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="507.2" y="43" fill="#267F99" font-size="15">String</text>
+    <text x="558.8" y="43" fill="#3B3B3B" font-size="15">)</text>
+    <text x="567.4" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="576.0" y="43" fill="#0000FF" font-size="15">-&gt;</text>
+    <text x="593.2" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="601.8" y="43" fill="#267F99" font-size="15">String</text>
+    <text x="653.4" y="43" fill="#3B3B3B" font-size="15"> </text>
+    <text x="662.0" y="43" fill="#3B3B3B" font-size="15">{</text>
+    <text x="26" y="65" fill="#6E7681" font-size="15"> 2</text>
+    <text x="60.0" y="65" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="65" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="65" fill="#001080" font-size="15">one</text>
+    <text x="137.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="65" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="171.8" y="65" fill="#A31515" font-size="15">before </text>
+    <text x="232.0" y="65" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="249.2" y="65" fill="#AF00DB" font-size="15">if</text>
+    <text x="266.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="275.0" y="65" fill="#001080" font-size="15">value</text>
+    <text x="318.0" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="326.6" y="65" fill="#000000" font-size="15">&gt;</text>
+    <text x="335.2" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="343.8" y="65" fill="#098658" font-size="15">0</text>
+    <text x="352.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="361.0" y="65" fill="#3B3B3B" font-size="15">{</text>
+    <text x="369.6" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="378.2" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="386.8" y="65" fill="#A31515" font-size="15">inner </text>
+    <text x="438.4" y="65" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="455.6" y="65" fill="#001080" font-size="15">name</text>
+    <text x="490.0" y="65" fill="#3B3B3B" font-size="15">}</text>
+    <text x="498.6" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="507.2" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="515.8" y="65" fill="#3B3B3B" font-size="15">}</text>
+    <text x="524.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="533.0" y="65" fill="#AF00DB" font-size="15">else</text>
+    <text x="567.4" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="576.0" y="65" fill="#3B3B3B" font-size="15">{</text>
+    <text x="584.6" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="593.2" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="601.8" y="65" fill="#A31515" font-size="15">none</text>
+    <text x="636.2" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="644.8" y="65" fill="#3B3B3B" font-size="15"> </text>
+    <text x="653.4" y="65" fill="#3B3B3B" font-size="15">}</text>
+    <text x="662.0" y="65" fill="#3B3B3B" font-size="15">}</text>
+    <text x="670.6" y="65" fill="#A31515" font-size="15"> after</text>
+    <text x="722.2" y="65" fill="#A31515" font-size="15">&quot;</text>
+    <text x="26" y="87" fill="#6E7681" font-size="15"> 3</text>
+    <text x="60.0" y="87" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="87" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="87" fill="#001080" font-size="15">two</text>
+    <text x="137.4" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="146.0" y="87" fill="#000000" font-size="15">=</text>
+    <text x="154.6" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="87" fill="#A31515" font-size="15">$|</text>
+    <text x="180.4" y="87" fill="#A31515" font-size="15">prefix </text>
+    <text x="240.6" y="87" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="257.8" y="87" fill="#AF00DB" font-size="15">match</text>
+    <text x="300.8" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="309.4" y="87" fill="#001080" font-size="15">value</text>
+    <text x="352.4" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="361.0" y="87" fill="#3B3B3B" font-size="15">{</text>
+    <text x="369.6" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="378.2" y="87" fill="#098658" font-size="15">0</text>
+    <text x="386.8" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="395.4" y="87" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="412.6" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="421.2" y="87" fill="#A31515" font-size="15">&quot;</text>
+    <text x="429.8" y="87" fill="#A31515" font-size="15">zero</text>
+    <text x="464.2" y="87" fill="#A31515" font-size="15">&quot;</text>
+    <text x="472.8" y="87" fill="#3B3B3B" font-size="15">;</text>
+    <text x="481.4" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="490.0" y="87" fill="#0000FF" font-size="15">_</text>
+    <text x="498.6" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="507.2" y="87" fill="#0000FF" font-size="15">=&gt;</text>
+    <text x="524.4" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="533.0" y="87" fill="#A31515" font-size="15">&quot;</text>
+    <text x="541.6" y="87" fill="#A31515" font-size="15">value </text>
+    <text x="593.2" y="87" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="610.4" y="87" fill="#001080" font-size="15">value</text>
+    <text x="653.4" y="87" fill="#3B3B3B" font-size="15">}</text>
+    <text x="662.0" y="87" fill="#A31515" font-size="15">&quot;</text>
+    <text x="670.6" y="87" fill="#3B3B3B" font-size="15"> </text>
+    <text x="679.2" y="87" fill="#3B3B3B" font-size="15">}</text>
+    <text x="687.8" y="87" fill="#3B3B3B" font-size="15">}</text>
+    <text x="696.4" y="87" fill="#A31515" font-size="15"> suffix</text>
+    <text x="26" y="109" fill="#6E7681" font-size="15"> 4</text>
+    <text x="60.0" y="109" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="109" fill="#0000FF" font-size="15">let</text>
+    <text x="103.0" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="109" fill="#001080" font-size="15">three</text>
+    <text x="154.6" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="109" fill="#000000" font-size="15">=</text>
+    <text x="171.8" y="109" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="109" fill="#811F3F" font-size="15">re</text>
+    <text x="197.6" y="109" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="206.2" y="109" fill="#811F3F" font-size="15">^item-</text>
+    <text x="257.8" y="109" fill="#3B3B3B" font-size="15">\{</text>
+    <text x="275.0" y="109" fill="#001080" font-size="15">value</text>
+    <text x="318.0" y="109" fill="#3B3B3B" font-size="15">}</text>
+    <text x="326.6" y="109" fill="#811F3F" font-size="15">$</text>
+    <text x="335.2" y="109" fill="#811F3F" font-size="15">&quot;</text>
+    <text x="26" y="131" fill="#6E7681" font-size="15"> 5</text>
+    <text x="60.0" y="131" fill="#3B3B3B" font-size="15">  </text>
+    <text x="77.2" y="131" fill="#001080" font-size="15">one</text>
+    <text x="103.0" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="111.6" y="131" fill="#000000" font-size="15">+</text>
+    <text x="120.2" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="128.8" y="131" fill="#001080" font-size="15">two</text>
+    <text x="154.6" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="163.2" y="131" fill="#000000" font-size="15">+</text>
+    <text x="171.8" y="131" fill="#3B3B3B" font-size="15"> </text>
+    <text x="180.4" y="131" fill="#001080" font-size="15">three</text>
+    <text x="26" y="153" fill="#6E7681" font-size="15"> 6</text>
+    <text x="60.0" y="153" fill="#3B3B3B" font-size="15">}</text>
+  </g>
+</svg>

--- a/grammars/moonbit-config.tmLanguage.json
+++ b/grammars/moonbit-config.tmLanguage.json
@@ -2,15 +2,19 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "moonbit-config",
   "scopeName": "source.moonbit.config",
+  "fileTypes": [
+    "moon.pkg",
+    "moon.mod"
+  ],
   "patterns": [
     {
       "include": "#configlinecomment"
     },
     {
-      "include": "#moonbit-config-property-name"
+      "include": "#configstring-property-name"
     },
     {
-      "include": "#moonbit-config-module-header"
+      "include": "#configident-property-name"
     },
     {
       "include": "#configstring-double"
@@ -19,16 +23,13 @@
       "include": "#configstring-single"
     },
     {
-      "include": "#module-destructure"
+      "include": "#module-namespace-declaration"
     },
     {
-      "include": "#package-destructure"
+      "include": "#package-namespace-declaration"
     },
     {
       "include": "#configint"
-    },
-    {
-      "include": "#moonbit-config-alias-as"
     },
     {
       "include": "#scope-keyword-operator-expression-as"
@@ -142,258 +143,42 @@
     },
     "configident": {
       "name": "variable.other.readwrite.moonbit.config",
-      "match": "[a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*"
+      "match": "[a-zA-Z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*"
+    },
+    "configstring-property-name": {
+      "match": "\"(?:[^\"\\\\\\n]|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.))*\"(?=\\s*[:=])",
+      "name": "support.type.property-name.moonbit.config"
+    },
+    "configident-property-name": {
+      "match": "[a-zA-Z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*(?=\\s*[:=])",
+      "name": "support.type.property-name.moonbit.config"
+    },
+    "module-namespace-declaration": {
+      "name": "meta.module.moonbit.config",
+      "begin": "\\b(module)\\b\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.moonbit.config"
+        }
+      },
+      "end": "$",
+      "contentName": "entity.name.namespace.moonbit.config"
+    },
+    "package-namespace-declaration": {
+      "name": "meta.package.moonbit.config",
+      "begin": "\\b(package)\\b\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.moonbit.config"
+        }
+      },
+      "end": "$",
+      "contentName": "entity.name.namespace.moonbit.config"
     },
     "type-inner": {
       "patterns": [
         {
           "include": "#simple-type"
-        }
-      ]
-    },
-    "bind-default": {
-      "begin": "(=)",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.operator.assignment.moonbit.config"
-        }
-      },
-      "end": "(?=[,}\\])])",
-      "patterns": [
-        {
-          "include": "$self"
-        }
-      ]
-    },
-    "const-bind-prop": {
-      "patterns": [
-        {
-          "match": "(\\.\\.\\.)",
-          "name": "keyword.operator.rest.moonbit.config"
-        },
-        {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(\\s*)(:)",
-          "captures": {
-            "1": {
-              "name": "variable.object.property.moonbit.config"
-            },
-            "3": {
-              "name": "punctuation.destructuring.moonbit.config"
-            }
-          }
-        },
-        {
-          "include": "#bind-default"
-        },
-        {
-          "include": "#const-bind-object"
-        },
-        {
-          "include": "#const-bind-array"
-        },
-        {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
-          "name": "variable.other.constant.moonbit.config"
-        },
-        {
-          "match": ",",
-          "name": "punctuation.separator.comma.moonbit.config"
-        }
-      ]
-    },
-    "const-bind-elem": {
-      "patterns": [
-        {
-          "match": "(\\.\\.\\.)",
-          "name": "keyword.operator.rest.moonbit.config"
-        },
-        {
-          "include": "#bind-default"
-        },
-        {
-          "include": "#const-bind-object"
-        },
-        {
-          "include": "#const-bind-array"
-        },
-        {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
-          "name": "variable.other.constant.moonbit.config"
-        },
-        {
-          "match": ",",
-          "name": "punctuation.separator.comma.moonbit.config"
-        }
-      ]
-    },
-    "const-bind-object": {
-      "begin": "\\{",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.object.moonbit.config"
-        }
-      },
-      "end": "\\}",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.object.moonbit.config"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#const-bind-prop"
-        }
-      ]
-    },
-    "const-bind-array": {
-      "begin": "\\[",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.array.moonbit.config"
-        }
-      },
-      "end": "\\]",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.array.moonbit.config"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#const-bind-elem"
-        }
-      ]
-    },
-    "mut-bind-prop": {
-      "patterns": [
-        {
-          "match": "(\\.\\.\\.)",
-          "name": "keyword.operator.rest.moonbit.config"
-        },
-        {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(\\s*)(:)",
-          "captures": {
-            "1": {
-              "name": "variable.object.property.moonbit.config"
-            },
-            "3": {
-              "name": "punctuation.destructuring.moonbit.config"
-            }
-          }
-        },
-        {
-          "include": "#bind-default"
-        },
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        },
-        {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
-          "name": "variable.other.readwrite.moonbit.config"
-        },
-        {
-          "match": ",",
-          "name": "punctuation.separator.comma.moonbit.config"
-        }
-      ]
-    },
-    "mut-bind-elem": {
-      "patterns": [
-        {
-          "match": "(\\.\\.\\.)",
-          "name": "keyword.operator.rest.moonbit.config"
-        },
-        {
-          "include": "#bind-default"
-        },
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        },
-        {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
-          "name": "variable.other.readwrite.moonbit.config"
-        },
-        {
-          "match": ",",
-          "name": "punctuation.separator.comma.moonbit.config"
-        }
-      ]
-    },
-    "mut-bind-object": {
-      "begin": "\\{",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.object.moonbit.config"
-        }
-      },
-      "end": "\\}",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.object.moonbit.config"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#mut-bind-prop"
-        }
-      ]
-    },
-    "mut-bind-array": {
-      "begin": "\\[",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.array.moonbit.config"
-        }
-      },
-      "end": "\\]",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.binding-pattern.array.moonbit.config"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#mut-bind-elem"
-        }
-      ]
-    },
-    "module-destructure": {
-      "begin": "\\b(module)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit.config"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "package-destructure": {
-      "begin": "\\b(package)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit.config"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
         }
       ]
     },
@@ -406,7 +191,7 @@
       "name": "constant.language.boolean.false.moonbit.config"
     },
     "scope-keyword-operator-expression-as": {
-      "match": "\\b(as)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$)",
+      "match": "\\b(as)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$)",
       "name": "keyword.operator.expression.moonbit.config"
     },
     "scope-keyword-control-import": {
@@ -464,40 +249,6 @@
     "scope-punctuation-terminator-statement": {
       "match": ";",
       "name": "punctuation.terminator.statement.moonbit.config"
-    },
-    "moonbit-config-property-name": {
-      "match": "((?:^|[,{(])\\s*)([A-Za-z_][A-Za-z0-9_]*|\"(?:[^\"\\\\\\n]|\\\\.)*\")(\\s*)([:=])",
-      "captures": {
-        "2": {
-          "name": "support.type.property-name.moonbit.config"
-        },
-        "4": {
-          "name": "keyword.operator.assignment.moonbit.config"
-        }
-      }
-    },
-    "moonbit-config-module-header": {
-      "match": "\\b(module|package)\\b\\s+((?:[A-Za-z_][A-Za-z0-9_]*)(?:/[A-Za-z_][A-Za-z0-9_]*)*|\"(?:[^\"\\\\\\n]|\\\\.)*\")",
-      "captures": {
-        "1": {
-          "name": "storage.type.moonbit.config"
-        },
-        "2": {
-          "name": "entity.name.namespace.moonbit.config"
-        }
-      }
-    },
-    "moonbit-config-alias-as": {
-      "match": "\\b(as)\\b(?=\\s*@)",
-      "captures": {
-        "1": {
-          "name": "keyword.operator.expression.moonbit.config"
-        }
-      }
     }
-  },
-  "fileTypes": [
-    "moon.pkg",
-    "moon.mod"
-  ]
+  }
 }

--- a/grammars/moonbit.tmLanguage.json
+++ b/grammars/moonbit.tmLanguage.json
@@ -2,6 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "moonbit",
   "scopeName": "source.moonbit",
+  "fileTypes": [
+    "mbt",
+    "mbtx",
+    "mbtp"
+  ],
   "patterns": [
     {
       "include": "#doccomment"
@@ -118,6 +123,9 @@
       "include": "#scope-keyword-control-proof"
     },
     {
+      "include": "#uident"
+    },
+    {
       "include": "#prooflabel"
     },
     {
@@ -136,21 +144,6 @@
       "include": "#moonbit-impl-header"
     },
     {
-      "include": "#moonbit-typealias-declaration"
-    },
-    {
-      "include": "#moonbit-traitalias-declaration"
-    },
-    {
-      "include": "#moonbit-type-declaration"
-    },
-    {
-      "include": "#moonbit-qualified-type"
-    },
-    {
-      "include": "#moonbit-type-name"
-    },
-    {
       "include": "#scope-storage-type"
     },
     {
@@ -161,12 +154,6 @@
     },
     {
       "include": "#scope-constant-language-boolean-false"
-    },
-    {
-      "include": "#scope-support-type-primitive"
-    },
-    {
-      "include": "#scope-support-class"
     },
     {
       "include": "#method-call"
@@ -294,25 +281,19 @@
       "match": "(?:0[xX][0-9a-fA-F][0-9a-fA-F_]*|0[oO][0-7][0-7_]*|0[bB][01][01_]*|[0-9][0-9_]*)(?:UL|U|L|N)?"
     },
     "regexliteral": {
-      "name": "string.regexp.moonbit",
-      "match": "re\"(?:[^\"\\\\\\n]|\\\\\\{(?:[^{}\\n\"'\\\\]|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.)|\"(?:[^\"\\\\\\n]|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.))*\"|'(?:[^'\\\\\\n]|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.))*'|\\{[^{}\\n]*\\})*\\}|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.))*\""
-    },
-    "bytes": {
-      "name": "string.quoted.double.bytes.moonbit",
-      "match": "b\"(?:[^\"\\\\\\n]|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.))*\""
-    },
-    "string-double": {
-      "name": "string.quoted.double.moonbit",
-      "begin": "\"",
+      "begin": "(re)(\")",
       "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.moonbit"
+        "1": {
+          "name": "string.regexp.moonbit"
+        },
+        "2": {
+          "name": "string.regexp.moonbit punctuation.definition.string.begin.moonbit"
         }
       },
       "end": "\"|$",
       "endCaptures": {
         "0": {
-          "name": "punctuation.definition.string.end.moonbit"
+          "name": "string.regexp.moonbit punctuation.definition.string.end.moonbit"
         }
       },
       "patterns": [
@@ -342,6 +323,61 @@
         {
           "match": "\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.)",
           "name": "constant.character.escape.moonbit"
+        },
+        {
+          "match": "(?:\\\\(?!\\{)|[^\"\\\\])+",
+          "name": "string.regexp.moonbit"
+        }
+      ]
+    },
+    "bytes": {
+      "name": "string.quoted.double.bytes.moonbit",
+      "match": "b\"(?:[^\"\\\\\\n]|\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.))*\""
+    },
+    "string-double": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "string.quoted.double.moonbit punctuation.definition.string.begin.moonbit"
+        }
+      },
+      "end": "\"|$",
+      "endCaptures": {
+        "0": {
+          "name": "string.quoted.double.moonbit punctuation.definition.string.end.moonbit"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.embedded.expression.moonbit",
+          "begin": "\\\\\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.begin.moonbit"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.end.moonbit"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#moonbit-interpolation-braces"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "match": "\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.)",
+          "name": "constant.character.escape.moonbit"
+        },
+        {
+          "match": "[^\"\\\\]+",
+          "name": "string.quoted.double.moonbit"
         }
       ]
     },
@@ -367,11 +403,10 @@
       ]
     },
     "multilineinterp": {
-      "name": "string.quoted.other.multiline.interpolated.moonbit",
       "begin": "\\$\\|",
       "beginCaptures": {
         "0": {
-          "name": "punctuation.definition.string.begin.moonbit"
+          "name": "string.quoted.other.multiline.interpolated.moonbit punctuation.definition.string.begin.moonbit"
         }
       },
       "end": "$",
@@ -398,6 +433,10 @@
               "include": "$self"
             }
           ]
+        },
+        {
+          "match": "(?:\\\\(?!\\{)|[^\\\\\\n])+",
+          "name": "string.quoted.other.multiline.interpolated.moonbit"
         }
       ]
     },
@@ -413,12 +452,16 @@
       "name": "constant.character.moonbit",
       "match": "'(?:\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.)|[^\\\\'\\n])+'"
     },
+    "uident": {
+      "name": "entity.name.type.moonbit",
+      "match": "[A-Z][A-Za-z0-9_]*\\??"
+    },
     "ident": {
       "name": "variable.other.readwrite.moonbit",
-      "match": "[a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*"
+      "match": "[a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*"
     },
     "simple-type": {
-      "match": "[a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*",
+      "match": "[a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*",
       "name": "entity.name.type.moonbit"
     },
     "type-paren": {
@@ -432,7 +475,7 @@
     },
     "type-object-member": {
       "name": "meta.type.annotation.member.moonbit",
-      "begin": "(#?[a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(\\??)(\\s*:)",
+      "begin": "(#?[a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(\\??)(\\s*:)",
       "beginCaptures": {
         "1": {
           "name": "variable.object.property.moonbit"
@@ -487,13 +530,13 @@
           "include": "#type-paren"
         },
         {
+          "include": "#uident"
+        },
+        {
           "include": "#doccomment"
         },
         {
           "include": "#linecomment"
-        },
-        {
-          "include": "#scope-support-type-primitive"
         },
         {
           "include": "#scope-constant-language-boolean-true"
@@ -524,7 +567,7 @@
       ]
     },
     "fn-definition": {
-      "match": "\\b(fn)\\s+([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
+      "match": "\\b(fn)\\s+([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)",
       "captures": {
         "1": {
           "name": "storage.type.function.moonbit"
@@ -555,7 +598,7 @@
           "name": "keyword.operator.rest.moonbit"
         },
         {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(\\s*)(:)",
+          "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(\\s*)(:)",
           "captures": {
             "1": {
               "name": "variable.object.property.moonbit"
@@ -575,7 +618,7 @@
           "include": "#const-bind-array"
         },
         {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
+          "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)",
           "name": "variable.other.constant.moonbit"
         },
         {
@@ -600,7 +643,7 @@
           "include": "#const-bind-array"
         },
         {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
+          "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)",
           "name": "variable.other.constant.moonbit"
         },
         {
@@ -654,7 +697,7 @@
           "name": "keyword.operator.rest.moonbit"
         },
         {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(\\s*)(:)",
+          "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(\\s*)(:)",
           "captures": {
             "1": {
               "name": "variable.object.property.moonbit"
@@ -674,7 +717,7 @@
           "include": "#mut-bind-array"
         },
         {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
+          "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)",
           "name": "variable.other.readwrite.moonbit"
         },
         {
@@ -699,7 +742,7 @@
           "include": "#mut-bind-array"
         },
         {
-          "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
+          "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)",
           "name": "variable.other.readwrite.moonbit"
         },
         {
@@ -781,7 +824,7 @@
       ]
     },
     "function-call": {
-      "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(?=\\s*\\()",
+      "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(?=\\s*\\()",
       "captures": {
         "1": {
           "name": "entity.name.function.moonbit"
@@ -789,7 +832,7 @@
       }
     },
     "object-method-key": {
-      "match": "([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(?=\\s*:\\s*(?:\\w+\\s+)?[\\(])",
+      "match": "([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(?=\\s*:\\s*(?:\\w+\\s+)?[\\(])",
       "captures": {
         "1": {
           "name": "entity.name.function.moonbit"
@@ -797,7 +840,7 @@
       }
     },
     "method-call": {
-      "match": "(?<=[\\w\\]\\)])(\\.)\\s*([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(?=\\s*\\()",
+      "match": "(?<=[\\w\\]\\)])(\\.)\\s*([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(?=\\s*\\()",
       "captures": {
         "1": {
           "name": "punctuation.accessor.moonbit"
@@ -819,7 +862,7 @@
       }
     },
     "property-access": {
-      "match": "(?<=[\\w\\]\\)])(\\.)\\s*([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)",
+      "match": "(?<=[\\w\\]\\)])(\\.)\\s*([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)",
       "captures": {
         "1": {
           "name": "punctuation.accessor.moonbit"
@@ -854,13 +897,13 @@
     },
     "as-typekw": {
       "name": "meta.type.as.moonbit",
-      "begin": "\\b(as)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$)",
+      "begin": "\\b(as)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$)",
       "beginCaptures": {
         "1": {
           "name": "keyword.operator.expression.as.moonbit"
         }
       },
-      "end": "(?=[)}{\\],;=>]|\\b(?:as|if|else|match|guard|lexmatch|for|while|loop|in|break|continue|return|raise|throw|defer|try|catch|import|using|proof_assert|proof_let|is|not)\\b)",
+      "end": "(?=[)}{\\],;=>]|\\b(?:as|if|else|match|guard|lexmatch|for|while|loop|in|break|continue|return|raise|throw|defer|try|catch|import|using|fn|predicate|lemma|let|letrec|const|type|struct|enum|enumview|extenum|trait|impl|typealias|traitalias|fnalias|suberror|test|pub|priv|readonly|extern|mut|async|declare|noraise|nobreak|proof_assert|proof_let|is|not)\\b)",
       "patterns": [
         {
           "include": "#type-inner"
@@ -869,7 +912,7 @@
     },
     "type-annotation-var": {
       "name": "meta.type.annotation.moonbit",
-      "begin": "\\b(let|const|letrec|type|struct|enum|extenum|suberror|enumview|typealias|traitalias|fnalias|trait|impl|test)\\s+([a-zA-Z_\\u0080-\\uFFFF\\p{L}\\p{Nl}][a-zA-Z0-9_\\u0080-\\uFFFF\\p{L}\\p{Nl}\\p{Nd}\\p{Mn}\\p{Mc}\\p{Pc}]*)(\\s*:)",
+      "begin": "\\b(let|const|letrec|type|struct|enum|extenum|suberror|enumview|typealias|traitalias|fnalias|trait|impl|test)\\s+([a-z_\\u0080-\\uFFFF][a-zA-Z0-9_\\u0080-\\uFFFF]*)(\\s*:)",
       "beginCaptures": {
         "1": {
           "name": "storage.type.moonbit"
@@ -904,12 +947,8 @@
       ]
     },
     "scope-keyword-other": {
-      "match": "\\b(_|Array|FixedArray|Option|Result|Json|where|with|all|open|derive|and)\\b",
+      "match": "\\b(_|Unit|Bool|Byte|Char|Int|Int64|UInt|UInt64|Float|Double|String|Bytes|Array|FixedArray|Option|Result|Json|where|with|all|open|derive|and)\\b",
       "name": "keyword.other.moonbit"
-    },
-    "scope-support-type-primitive": {
-      "match": "\\b(Unit|Bool|Byte|Char|Int|Int64|UInt|UInt64|Float|Double|String|Bytes)\\b",
-      "name": "support.type.primitive.moonbit"
     },
     "scope-storage-modifier": {
       "match": "\\b(async|pub|priv|readonly|extern)\\b",
@@ -936,39 +975,39 @@
       "name": "keyword.control.conditional.moonbit"
     },
     "scope-keyword-operator-expression-as": {
-      "match": "\\b(as)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$)",
+      "match": "\\b(as)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$)",
       "name": "keyword.operator.expression.moonbit"
     },
     "scope-keyword-operator-expression-is": {
-      "match": "\\b(is)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$)",
+      "match": "\\b(is)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$)",
       "name": "keyword.operator.expression.moonbit"
     },
     "scope-keyword-operator-expression-not": {
-      "match": "\\b(not)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$)",
+      "match": "\\b(not)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$)",
       "name": "keyword.operator.expression.moonbit"
     },
     "scope-keyword-control-loop-for": {
-      "match": "\\b(for)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$|\\s*[({\\[\"])",
+      "match": "\\b(for)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$|\\s*[({\\[\"])",
       "name": "keyword.control.loop.moonbit"
     },
     "scope-keyword-control-loop-in": {
-      "match": "\\b(in)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$|\\s*[({\\[\"])",
+      "match": "\\b(in)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$|\\s*[({\\[\"])",
       "name": "keyword.control.loop.moonbit"
     },
     "scope-keyword-control-loop-loop": {
-      "match": "\\b(loop)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$|\\s*[({\\[\"])",
+      "match": "\\b(loop)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$|\\s*[({\\[\"])",
       "name": "keyword.control.loop.moonbit"
     },
     "scope-keyword-control-loop-while": {
-      "match": "\\b(while)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$|\\s*[({\\[\"])",
+      "match": "\\b(while)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$|\\s*[({\\[\"])",
       "name": "keyword.control.loop.moonbit"
     },
     "scope-keyword-control-loop-break": {
-      "match": "\\b(break)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$|\\s*[({\\[\"])",
+      "match": "\\b(break)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$|\\s*[({\\[\"])",
       "name": "keyword.control.loop.moonbit"
     },
     "scope-keyword-control-loop-continue": {
-      "match": "\\b(continue)\\b(?=\\s+[[:alpha:][:digit:]_\"({\\[]|\\s*$|\\s*[({\\[\"])",
+      "match": "\\b(continue)\\b(?=\\s+[[:alpha:][:digit:]_@\"({\\[]|\\s*$|\\s*[({\\[\"])",
       "name": "keyword.control.loop.moonbit"
     },
     "scope-storage-type-function": {
@@ -990,10 +1029,6 @@
     "scope-keyword-control-proof": {
       "match": "\\b(proof_assert|proof_let)\\b",
       "name": "keyword.control.proof.moonbit"
-    },
-    "scope-support-class": {
-      "match": "\\b(Eq|Compare|Hash|Show|Default|ToJson|FromJson|Error)\\b",
-      "name": "support.class.moonbit"
     },
     "scope-punctuation-accessor": {
       "match": "\\.",
@@ -1256,6 +1291,9 @@
           "include": "#scope-keyword-control-exception"
         },
         {
+          "include": "#uident"
+        },
+        {
           "include": "#prooflabel"
         },
         {
@@ -1278,12 +1316,6 @@
         },
         {
           "include": "#scope-constant-language-boolean-false"
-        },
-        {
-          "include": "#scope-support-type-primitive"
-        },
-        {
-          "include": "#scope-support-class"
         },
         {
           "include": "#method-call"
@@ -1372,76 +1404,6 @@
         }
       ]
     },
-    "moonbit-typealias-declaration": {
-      "match": "\\b(typealias)\\b\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*))?",
-      "captures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        },
-        "2": {
-          "name": "entity.name.type.moonbit"
-        },
-        "3": {
-          "name": "keyword.operator.expression.as.moonbit"
-        },
-        "4": {
-          "name": "entity.name.type.moonbit"
-        }
-      }
-    },
-    "moonbit-traitalias-declaration": {
-      "match": "\\b(traitalias)\\b\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*([a-zA-Z_][a-zA-Z0-9_]*))?",
-      "captures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        },
-        "2": {
-          "name": "entity.name.type.moonbit"
-        },
-        "3": {
-          "name": "keyword.operator.assignment.moonbit"
-        },
-        "4": {
-          "name": "entity.name.type.moonbit"
-        }
-      }
-    },
-    "moonbit-type-declaration": {
-      "match": "\\b(type|struct|enum|extenum|suberror|trait)\\b\\s*(!)?\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-      "captures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        },
-        "2": {
-          "name": "keyword.operator.moonbit"
-        },
-        "3": {
-          "name": "entity.name.type.moonbit"
-        }
-      }
-    },
-    "moonbit-qualified-type": {
-      "match": "(@[a-zA-Z_][a-zA-Z0-9_]*(?:/[a-zA-Z_][a-zA-Z0-9_]*)*)(\\.)([A-Z][A-Za-z0-9_]*\\?*)",
-      "captures": {
-        "1": {
-          "name": "entity.name.namespace.moonbit"
-        },
-        "2": {
-          "name": "punctuation.accessor.moonbit"
-        },
-        "3": {
-          "name": "entity.name.type.moonbit"
-        }
-      }
-    },
-    "moonbit-type-name": {
-      "match": "\\b(?<!@)([A-Z][A-Za-z0-9_]*\\?*)",
-      "captures": {
-        "1": {
-          "name": "entity.name.type.moonbit"
-        }
-      }
-    },
     "moonbit-impl-header": {
       "name": "meta.impl.header.moonbit",
       "begin": "\\b(impl)\\b",
@@ -1457,35 +1419,12 @@
           "name": "keyword.other.impl.moonbit"
         },
         {
-          "include": "#moonbit-qualified-type"
+          "include": "#type-inner"
         },
         {
-          "include": "#moonbit-type-name"
-        },
-        {
-          "include": "#scope-support-type-primitive"
-        },
-        {
-          "include": "#scope-support-class"
-        },
-        {
-          "include": "#scope-punctuation-separator-colon"
-        },
-        {
-          "include": "#scope-punctuation-separator-comma"
-        },
-        {
-          "include": "#scope-punctuation-bracket-square"
-        },
-        {
-          "include": "#scope-punctuation-accessor"
+          "include": "$self"
         }
       ]
     }
-  },
-  "fileTypes": [
-    "mbt",
-    "mbtx",
-    "mbtp"
-  ]
+  }
 }

--- a/grammars/moonbit.tmLanguage.json
+++ b/grammars/moonbit.tmLanguage.json
@@ -49,46 +49,7 @@
       "include": "#let-destructure"
     },
     {
-      "include": "#letrec-destructure"
-    },
-    {
       "include": "#const-destructure"
-    },
-    {
-      "include": "#type-destructure"
-    },
-    {
-      "include": "#struct-destructure"
-    },
-    {
-      "include": "#enum-destructure"
-    },
-    {
-      "include": "#enumview-destructure"
-    },
-    {
-      "include": "#extenum-destructure"
-    },
-    {
-      "include": "#trait-destructure"
-    },
-    {
-      "include": "#impl-destructure"
-    },
-    {
-      "include": "#typealias-destructure"
-    },
-    {
-      "include": "#traitalias-destructure"
-    },
-    {
-      "include": "#fnalias-destructure"
-    },
-    {
-      "include": "#suberror-destructure"
-    },
-    {
-      "include": "#test-destructure"
     },
     {
       "include": "#as-typekw"
@@ -356,6 +317,29 @@
       },
       "patterns": [
         {
+          "name": "meta.embedded.expression.moonbit",
+          "begin": "\\\\\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.begin.moonbit"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.end.moonbit"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#moonbit-interpolation-braces"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
           "match": "\\\\(?:['\"\\\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\\{[0-9a-fA-F]+\\}|.)",
           "name": "constant.character.escape.moonbit"
         }
@@ -384,7 +368,38 @@
     },
     "multilineinterp": {
       "name": "string.quoted.other.multiline.interpolated.moonbit",
-      "match": "\\$\\|[^\\n]*"
+      "begin": "\\$\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.moonbit"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "name": "meta.embedded.expression.moonbit",
+          "begin": "\\\\\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.begin.moonbit"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.end.moonbit"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#moonbit-interpolation-braces"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
     },
     "multilinestring": {
       "name": "string.quoted.other.multiline.moonbit",
@@ -748,229 +763,8 @@
         }
       ]
     },
-    "letrec-destructure": {
-      "begin": "\\b(letrec)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
     "const-destructure": {
       "begin": "\\b(const)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "type-destructure": {
-      "begin": "\\b(type)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "struct-destructure": {
-      "begin": "\\b(struct)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "enum-destructure": {
-      "begin": "\\b(enum)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "enumview-destructure": {
-      "begin": "\\b(enumview)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "extenum-destructure": {
-      "begin": "\\b(extenum)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "trait-destructure": {
-      "begin": "\\b(trait)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "impl-destructure": {
-      "begin": "\\b(impl)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "typealias-destructure": {
-      "begin": "\\b(typealias)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "traitalias-destructure": {
-      "begin": "\\b(traitalias)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "fnalias-destructure": {
-      "begin": "\\b(fnalias)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "suberror-destructure": {
-      "begin": "\\b(suberror)\\s+(?=[{\\[])",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.moonbit"
-        }
-      },
-      "end": "(?<=[}\\]])",
-      "patterns": [
-        {
-          "include": "#mut-bind-object"
-        },
-        {
-          "include": "#mut-bind-array"
-        }
-      ]
-    },
-    "test-destructure": {
-      "begin": "\\b(test)\\s+(?=[{\\[])",
       "beginCaptures": {
         "1": {
           "name": "storage.type.moonbit"
@@ -1553,6 +1347,28 @@
         },
         {
           "include": "#char"
+        }
+      ]
+    },
+    "moonbit-interpolation-braces": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.moonbit"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.moonbit"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#moonbit-interpolation-braces"
+        },
+        {
+          "include": "$self"
         }
       ]
     },

--- a/grammars/moonbit.tmLanguage.json
+++ b/grammars/moonbit.tmLanguage.json
@@ -154,6 +154,12 @@
       "include": "#scope-keyword-control-import"
     },
     {
+      "include": "#scope-keyword-control-proof"
+    },
+    {
+      "include": "#prooflabel"
+    },
+    {
       "include": "#scope-keyword-other"
     },
     {
@@ -209,6 +215,15 @@
     },
     {
       "include": "#property-access"
+    },
+    {
+      "include": "#forall"
+    },
+    {
+      "include": "#exists"
+    },
+    {
+      "include": "#implies"
     },
     {
       "include": "#operator-overrides"
@@ -280,6 +295,22 @@
     "lexmatchquestion": {
       "name": "keyword.control.conditional.moonbit",
       "match": "lexmatch\\?"
+    },
+    "forall": {
+      "name": "keyword.operator.quantifier.moonbit",
+      "match": "∀"
+    },
+    "exists": {
+      "name": "keyword.operator.quantifier.moonbit",
+      "match": "∃"
+    },
+    "implies": {
+      "name": "keyword.operator.logical.implication.moonbit",
+      "match": "→"
+    },
+    "prooflabel": {
+      "name": "keyword.other.proof-label.moonbit",
+      "match": "proof_(?:require|ensure|invariant|yield|decrease|reasoning|axiomatized)(?=\\s*:)"
     },
     "dotint": {
       "name": "constant.numeric.integer.tuple-index.moonbit",
@@ -1035,7 +1066,7 @@
           "name": "keyword.operator.expression.as.moonbit"
         }
       },
-      "end": "(?=[)}{\\],;=>]|\\b(?:as|if|else|match|guard|lexmatch|for|while|loop|in|break|continue|return|raise|throw|defer|try|catch|import|using|is|not)\\b)",
+      "end": "(?=[)}{\\],;=>]|\\b(?:as|if|else|match|guard|lexmatch|for|while|loop|in|break|continue|return|raise|throw|defer|try|catch|import|using|proof_assert|proof_let|is|not)\\b)",
       "patterns": [
         {
           "include": "#type-inner"
@@ -1056,7 +1087,7 @@
           "name": "keyword.operator.type.annotation.moonbit"
         }
       },
-      "end": "(?=[=;,])|^\\s*(?=if|else|match|guard|lexmatch|for|while|loop|in|break|continue|return|throw|defer|try|catch|import|using|fn|let|letrec|const|type|struct|enum|enumview|extenum|trait|impl|typealias|traitalias|fnalias|suberror|test|pub|priv|readonly|extern|mut|declare|nobreak)\\b",
+      "end": "(?=[=;,])|^\\s*(?=if|else|match|guard|lexmatch|for|while|loop|in|break|continue|return|throw|defer|try|catch|import|using|fn|predicate|lemma|let|letrec|const|type|struct|enum|enumview|extenum|trait|impl|typealias|traitalias|fnalias|suberror|test|pub|priv|readonly|extern|mut|declare|nobreak|proof_assert|proof_let)\\b",
       "patterns": [
         {
           "include": "#type-inner"
@@ -1079,7 +1110,7 @@
       ]
     },
     "scope-keyword-other": {
-      "match": "\\b(_|Array|FixedArray|Option|Result|Json|with|where|all|open|derive|and)\\b",
+      "match": "\\b(_|Array|FixedArray|Option|Result|Json|where|with|all|open|derive|and)\\b",
       "name": "keyword.other.moonbit"
     },
     "scope-support-type-primitive": {
@@ -1147,7 +1178,7 @@
       "name": "keyword.control.loop.moonbit"
     },
     "scope-storage-type-function": {
-      "match": "\\b(fn)\\b",
+      "match": "\\b(fn|predicate|lemma)\\b",
       "name": "storage.type.function.moonbit"
     },
     "scope-keyword-control-exception": {
@@ -1161,6 +1192,10 @@
     "scope-keyword-control-import": {
       "match": "\\b(import|using)\\b",
       "name": "keyword.control.import.moonbit"
+    },
+    "scope-keyword-control-proof": {
+      "match": "\\b(proof_assert|proof_let)\\b",
+      "name": "keyword.control.proof.moonbit"
     },
     "scope-support-class": {
       "match": "\\b(Eq|Compare|Hash|Show|Default|ToJson|FromJson|Error)\\b",
@@ -1427,6 +1462,9 @@
           "include": "#scope-keyword-control-exception"
         },
         {
+          "include": "#prooflabel"
+        },
+        {
           "include": "#scope-keyword-other"
         },
         {
@@ -1461,6 +1499,15 @@
         },
         {
           "include": "#property-access"
+        },
+        {
+          "include": "#forall"
+        },
+        {
+          "include": "#exists"
+        },
+        {
+          "include": "#implies"
         },
         {
           "include": "#operator-overrides"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "generate:check": "tsx scripts/generate.ts --check",
     "preview:highlight": "tsx scripts/render-preview.ts",
     "test:parser": "tsx scripts/parser-smoke.ts",
-    "test:highlight": "vscode-tmgrammar-test -g grammars/moonbit.tmLanguage.json -g grammars/moonbit-config.tmLanguage.json 'tests/**/*.mbt' 'tests/**/moon.pkg' 'tests/**/moon.mod'",
+    "test:highlight": "vscode-tmgrammar-test -g grammars/moonbit.tmLanguage.json -g grammars/moonbit-config.tmLanguage.json 'tests/**/*.mbt' 'tests/**/*.mbtp' 'tests/**/moon.pkg' 'tests/**/moon.mod'",
     "test": "npm run generate:check && npm run test:parser && npm run test:highlight"
   },
   "devDependencies": {

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -30,8 +30,82 @@ function insertPatternsBefore(patterns: TmPattern[], beforeInclude: string, addi
   patterns.splice(index === -1 ? patterns.length : index, 0, ...missing);
 }
 
+function removePatternsByInclude(patterns: TmPattern[], includes: Set<string>): void {
+  for (let index = patterns.length - 1; index >= 0; index--) {
+    const include = patterns[index].include;
+    if (include && includes.has(include)) {
+      patterns.splice(index, 1);
+    }
+  }
+}
+
+function removeInvalidDeclarationDestructures(tmLanguage: TmGrammar): void {
+  const validDestructureRules = new Set(['let-destructure', 'const-destructure']);
+  const invalidDestructureRules = Object.keys(tmLanguage.repository)
+    .filter(key => key.endsWith('-destructure') && !validDestructureRules.has(key));
+  const invalidIncludes = new Set(invalidDestructureRules.map(key => `#${key}`));
+
+  removePatternsByInclude(tmLanguage.patterns, invalidIncludes);
+  for (const key of invalidDestructureRules) {
+    delete tmLanguage.repository[key];
+  }
+}
+
+function moonBitInterpolationPattern(): TmPattern {
+  return {
+    name: 'meta.embedded.expression.moonbit',
+    begin: String.raw`\\\{`,
+    beginCaptures: {
+      '0': { name: 'punctuation.definition.template-expression.begin.moonbit' },
+    },
+    end: String.raw`\}`,
+    endCaptures: {
+      '0': { name: 'punctuation.definition.template-expression.end.moonbit' },
+    },
+    patterns: [
+      { include: '#moonbit-interpolation-braces' },
+      { include: '$self' },
+    ],
+  };
+}
+
+function addMoonBitStringInterpolation(tmLanguage: TmGrammar): void {
+  tmLanguage.repository['moonbit-interpolation-braces'] = {
+    begin: String.raw`\{`,
+    beginCaptures: {
+      '0': { name: 'punctuation.definition.block.moonbit' },
+    },
+    end: String.raw`\}`,
+    endCaptures: {
+      '0': { name: 'punctuation.definition.block.moonbit' },
+    },
+    patterns: [
+      { include: '#moonbit-interpolation-braces' },
+      { include: '$self' },
+    ],
+  };
+
+  const interpolationPattern = moonBitInterpolationPattern();
+  const stringDouble = tmLanguage.repository['string-double'];
+  if (stringDouble?.patterns) {
+    stringDouble.patterns.unshift(interpolationPattern);
+  }
+
+  tmLanguage.repository['multilineinterp'] = {
+    name: 'string.quoted.other.multiline.interpolated.moonbit',
+    begin: String.raw`\$\|`,
+    beginCaptures: {
+      '0': { name: 'punctuation.definition.string.begin.moonbit' },
+    },
+    end: '$',
+    patterns: [moonBitInterpolationPattern()],
+  };
+}
+
 function addMoonBitTextMateOverlays(tmLanguage: TmGrammar): TmGrammar {
   tmLanguage.fileTypes = ['mbt', 'mbtx', 'mbtp'];
+  removeInvalidDeclarationDestructures(tmLanguage);
+  addMoonBitStringInterpolation(tmLanguage);
 
   // Monogram's generic TextMate inference is intentionally language-agnostic.
   // MoonBit's conventional UpperCamelCase type names benefit from a small

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -12,11 +12,11 @@ type TmPattern = {
   end?: string;
   captures?: Record<string, TmPattern>;
   beginCaptures?: Record<string, TmPattern>;
+  endCaptures?: Record<string, TmPattern>;
   patterns?: TmPattern[];
 };
 
 type TmGrammar = {
-  fileTypes?: string[];
   repository: Record<string, TmPattern>;
   patterns: TmPattern[];
 };
@@ -28,27 +28,6 @@ function insertPatternsBefore(patterns: TmPattern[], beforeInclude: string, addi
 
   const index = patterns.findIndex(pattern => pattern.include === beforeInclude);
   patterns.splice(index === -1 ? patterns.length : index, 0, ...missing);
-}
-
-function removePatternsByInclude(patterns: TmPattern[], includes: Set<string>): void {
-  for (let index = patterns.length - 1; index >= 0; index--) {
-    const include = patterns[index].include;
-    if (include && includes.has(include)) {
-      patterns.splice(index, 1);
-    }
-  }
-}
-
-function removeInvalidDeclarationDestructures(tmLanguage: TmGrammar): void {
-  const validDestructureRules = new Set(['let-destructure', 'const-destructure']);
-  const invalidDestructureRules = Object.keys(tmLanguage.repository)
-    .filter(key => key.endsWith('-destructure') && !validDestructureRules.has(key));
-  const invalidIncludes = new Set(invalidDestructureRules.map(key => `#${key}`));
-
-  removePatternsByInclude(tmLanguage.patterns, invalidIncludes);
-  for (const key of invalidDestructureRules) {
-    delete tmLanguage.repository[key];
-  }
 }
 
 function moonBitInterpolationPattern(): TmPattern {
@@ -69,6 +48,19 @@ function moonBitInterpolationPattern(): TmPattern {
   };
 }
 
+function moonBitEscapePattern(): TmPattern {
+  return {
+    match: String.raw`\\(?:['"\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]+\}|.)`,
+    name: 'constant.character.escape.moonbit',
+  };
+}
+
+function moonBitStringDelimiterScope(stringScope: string, edge: 'begin' | 'end'): TmPattern {
+  return {
+    name: `${stringScope}.moonbit punctuation.definition.string.${edge}.moonbit`,
+  };
+}
+
 function addMoonBitStringInterpolation(tmLanguage: TmGrammar): void {
   tmLanguage.repository['moonbit-interpolation-braces'] = {
     begin: String.raw`\{`,
@@ -86,154 +78,75 @@ function addMoonBitStringInterpolation(tmLanguage: TmGrammar): void {
   };
 
   const interpolationPattern = moonBitInterpolationPattern();
-  const stringDouble = tmLanguage.repository['string-double'];
-  if (stringDouble?.patterns) {
-    stringDouble.patterns.unshift(interpolationPattern);
-  }
+  tmLanguage.repository['string-double'] = {
+    begin: '"',
+    beginCaptures: {
+      '0': moonBitStringDelimiterScope('string.quoted.double', 'begin'),
+    },
+    end: '"|$',
+    endCaptures: {
+      '0': moonBitStringDelimiterScope('string.quoted.double', 'end'),
+    },
+    patterns: [
+      interpolationPattern,
+      moonBitEscapePattern(),
+      { match: String.raw`[^"\\]+`, name: 'string.quoted.double.moonbit' },
+    ],
+  };
+
+  tmLanguage.repository['regexliteral'] = {
+    begin: String.raw`(re)(")`,
+    beginCaptures: {
+      '1': { name: 'string.regexp.moonbit' },
+      '2': moonBitStringDelimiterScope('string.regexp', 'begin'),
+    },
+    end: '"|$',
+    endCaptures: {
+      '0': moonBitStringDelimiterScope('string.regexp', 'end'),
+    },
+    patterns: [
+      interpolationPattern,
+      moonBitEscapePattern(),
+      { match: String.raw`(?:\\(?!\{)|[^"\\])+`, name: 'string.regexp.moonbit' },
+    ],
+  };
 
   tmLanguage.repository['multilineinterp'] = {
-    name: 'string.quoted.other.multiline.interpolated.moonbit',
     begin: String.raw`\$\|`,
     beginCaptures: {
-      '0': { name: 'punctuation.definition.string.begin.moonbit' },
+      '0': moonBitStringDelimiterScope('string.quoted.other.multiline.interpolated', 'begin'),
     },
     end: '$',
-    patterns: [moonBitInterpolationPattern()],
+    patterns: [
+      moonBitInterpolationPattern(),
+      { match: String.raw`(?:\\(?!\{)|[^\\\n])+`, name: 'string.quoted.other.multiline.interpolated.moonbit' },
+    ],
   };
 }
 
-function addMoonBitTextMateOverlays(tmLanguage: TmGrammar): TmGrammar {
-  tmLanguage.fileTypes = ['mbt', 'mbtx', 'mbtp'];
-  removeInvalidDeclarationDestructures(tmLanguage);
-  addMoonBitStringInterpolation(tmLanguage);
-
-  // Monogram's generic TextMate inference is intentionally language-agnostic.
-  // MoonBit's conventional UpperCamelCase type names benefit from a small
-  // deterministic overlay, replacing the old handwritten type-name pattern while
-  // keeping grammars/moonbit.tmLanguage.json generated.
-  tmLanguage.repository['moonbit-typealias-declaration'] = {
-    match: '\\b(typealias)\\b\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*))?',
-    captures: {
-      '1': { name: 'storage.type.moonbit' },
-      '2': { name: 'entity.name.type.moonbit' },
-      '3': { name: 'keyword.operator.expression.as.moonbit' },
-      '4': { name: 'entity.name.type.moonbit' },
-    },
-  };
-
-  tmLanguage.repository['moonbit-traitalias-declaration'] = {
-    match: '\\b(traitalias)\\b\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*([a-zA-Z_][a-zA-Z0-9_]*))?',
-    captures: {
-      '1': { name: 'storage.type.moonbit' },
-      '2': { name: 'entity.name.type.moonbit' },
-      '3': { name: 'keyword.operator.assignment.moonbit' },
-      '4': { name: 'entity.name.type.moonbit' },
-    },
-  };
-
-  tmLanguage.repository['moonbit-type-declaration'] = {
-    match: '\\b(type|struct|enum|extenum|suberror|trait)\\b\\s*(!)?\\s+([a-zA-Z_][a-zA-Z0-9_]*)',
-    captures: {
-      '1': { name: 'storage.type.moonbit' },
-      '2': { name: 'keyword.operator.moonbit' },
-      '3': { name: 'entity.name.type.moonbit' },
-    },
-  };
-
-  tmLanguage.repository['moonbit-qualified-type'] = {
-    match: '(@[a-zA-Z_][a-zA-Z0-9_]*(?:/[a-zA-Z_][a-zA-Z0-9_]*)*)(\\.)([A-Z][A-Za-z0-9_]*\\?*)',
-    captures: {
-      '1': { name: 'entity.name.namespace.moonbit' },
-      '2': { name: 'punctuation.accessor.moonbit' },
-      '3': { name: 'entity.name.type.moonbit' },
-    },
-  };
-
-  tmLanguage.repository['moonbit-type-name'] = {
-    match: '\\b(?<!@)([A-Z][A-Za-z0-9_]*\\?*)',
-    captures: {
-      '1': { name: 'entity.name.type.moonbit' },
-    },
-  };
-
-  // VS Code themes commonly color variable.other.property, while
-  // entity.other.property is mostly used for markup attributes.
-  tmLanguage.repository['property-access']!.captures!['2'] = {
-    name: 'variable.other.property.moonbit',
-  };
-
-  if (tmLanguage.repository['optional-property-access']?.captures) {
-    tmLanguage.repository['optional-property-access'].captures['2'] = {
-      name: 'variable.other.property.moonbit',
-    };
-  }
-
+function addMoonBitImplHeader(tmLanguage: TmGrammar): void {
   tmLanguage.repository['moonbit-impl-header'] = {
     name: 'meta.impl.header.moonbit',
-    begin: '\\b(impl)\\b',
+    begin: String.raw`\b(impl)\b`,
     beginCaptures: {
       '1': { name: 'storage.type.moonbit' },
     },
-    end: '(?=\\bwith\\b|[;{]|$)',
+    end: String.raw`(?=\bwith\b|[;{]|$)`,
     patterns: [
-      { match: '\\b(for)\\b', name: 'keyword.other.impl.moonbit' },
-      { include: '#moonbit-qualified-type' },
-      { include: '#moonbit-type-name' },
-      { include: '#scope-support-type-primitive' },
-      { include: '#scope-support-class' },
-      { include: '#scope-punctuation-separator-colon' },
-      { include: '#scope-punctuation-separator-comma' },
-      { include: '#scope-punctuation-bracket-square' },
-      { include: '#scope-punctuation-accessor' },
+      { match: String.raw`\b(for)\b`, name: 'keyword.other.impl.moonbit' },
+      { include: '#type-inner' },
+      { include: '$self' },
     ],
   };
 
   insertPatternsBefore(tmLanguage.patterns, '#scope-storage-type', [
     { include: '#moonbit-impl-header' },
-    { include: '#moonbit-typealias-declaration' },
-    { include: '#moonbit-traitalias-declaration' },
-    { include: '#moonbit-type-declaration' },
-    { include: '#moonbit-qualified-type' },
-    { include: '#moonbit-type-name' },
   ]);
-
-  return tmLanguage;
 }
 
-function addMoonBitConfigTextMateOverlays(tmLanguage: TmGrammar): TmGrammar {
-  tmLanguage.fileTypes = ['moon.pkg', 'moon.mod'];
-
-  tmLanguage.repository['moonbit-config-property-name'] = {
-    match: '((?:^|[,{(])\\s*)([A-Za-z_][A-Za-z0-9_]*|"(?:[^"\\\\\\n]|\\\\.)*")(\\s*)([:=])',
-    captures: {
-      '2': { name: 'support.type.property-name.moonbit.config' },
-      '4': { name: 'keyword.operator.assignment.moonbit.config' },
-    },
-  };
-
-  tmLanguage.repository['moonbit-config-module-header'] = {
-    match: '\\b(module|package)\\b\\s+((?:[A-Za-z_][A-Za-z0-9_]*)(?:/[A-Za-z_][A-Za-z0-9_]*)*|"(?:[^"\\\\\\n]|\\\\.)*")',
-    captures: {
-      '1': { name: 'storage.type.moonbit.config' },
-      '2': { name: 'entity.name.namespace.moonbit.config' },
-    },
-  };
-
-  tmLanguage.repository['moonbit-config-alias-as'] = {
-    match: '\\b(as)\\b(?=\\s*@)',
-    captures: {
-      '1': { name: 'keyword.operator.expression.moonbit.config' },
-    },
-  };
-
-  insertPatternsBefore(tmLanguage.patterns, '#configstring-double', [
-    { include: '#moonbit-config-property-name' },
-    { include: '#moonbit-config-module-header' },
-  ]);
-  insertPatternsBefore(tmLanguage.patterns, '#scope-keyword-operator-expression-as', [
-    { include: '#moonbit-config-alias-as' },
-  ]);
-
+function patchMoonBitTmLanguage(tmLanguage: TmGrammar): TmGrammar {
+  addMoonBitStringInterpolation(tmLanguage);
+  addMoonBitImplHeader(tmLanguage);
   return tmLanguage;
 }
 
@@ -241,7 +154,7 @@ const grammars = [
   {
     outPath: resolve('grammars/moonbit.tmLanguage.json'),
     generated: JSON.stringify(
-      addMoonBitTextMateOverlays(generateTmLanguage(sourceGrammar, sourceGrammar.name) as TmGrammar),
+      patchMoonBitTmLanguage(generateTmLanguage(sourceGrammar, sourceGrammar.name)),
       null,
       2,
     ) + '\n',
@@ -249,7 +162,7 @@ const grammars = [
   {
     outPath: resolve('grammars/moonbit-config.tmLanguage.json'),
     generated: JSON.stringify(
-      addMoonBitConfigTextMateOverlays(generateTmLanguage(configGrammar, configGrammar.name) as TmGrammar),
+      generateTmLanguage(configGrammar, configGrammar.name),
       null,
       2,
     ) + '\n',

--- a/scripts/parser-smoke.ts
+++ b/scripts/parser-smoke.ts
@@ -10,7 +10,10 @@ const fixtureRoot = resolve('tests/fixtures');
 const ignoredDirs = new Set(['.git', '_build', 'node_modules', 'target']);
 
 function isMoonBitFile(path: string): boolean {
-  return path.endsWith('.mbt') || path.endsWith('/moon.pkg') || path.endsWith('/moon.mod');
+  return path.endsWith('.mbt')
+    || path.endsWith('.mbtp')
+    || path.endsWith('/moon.pkg')
+    || path.endsWith('/moon.mod');
 }
 
 function fileKind(path: string): number {
@@ -19,7 +22,7 @@ function fileKind(path: string): number {
 }
 
 function parserFor(path: string): typeof sourceParser {
-  return path.endsWith('.mbt') ? sourceParser : configParser;
+  return path.endsWith('.mbt') || path.endsWith('.mbtp') ? sourceParser : configParser;
 }
 
 async function collectMoonBitFiles(dir: string): Promise<string[]> {

--- a/scripts/render-preview.ts
+++ b/scripts/render-preview.ts
@@ -27,7 +27,7 @@ const registry = new vsctm.Registry({
 });
 
 function scopeForSource(path: string): string {
-  return path.endsWith('.mbt') ? 'source.moonbit' : 'source.moonbit.config';
+  return path.endsWith('.mbt') || path.endsWith('.mbtp') ? 'source.moonbit' : 'source.moonbit.config';
 }
 
 function escapeXml(text: string): string {
@@ -119,7 +119,10 @@ function colorFor(scopes: string[]): string {
 }
 
 function isMoonBitFile(path: string): boolean {
-  return path.endsWith('.mbt') || path.endsWith('/moon.pkg') || path.endsWith('/moon.mod');
+  return path.endsWith('.mbt')
+    || path.endsWith('.mbtp')
+    || path.endsWith('/moon.pkg')
+    || path.endsWith('/moon.mod');
 }
 
 async function collectMoonBitFiles(dir: string): Promise<string[]> {
@@ -145,14 +148,14 @@ function withSvgExtension(path: string): string {
 function defaultSvgPathFor(sourcePath: string): string {
   if (sourcePath.startsWith(`${fixtureRoot}/`)) {
     const relativePath = relative(fixtureRoot, sourcePath);
-    const fixtureRelativePath = relativePath.endsWith('.mbt')
-      ? relativePath.replace(/\.mbt$/, '.svg')
+    const fixtureRelativePath = relativePath.endsWith('.mbt') || relativePath.endsWith('.mbtp')
+      ? relativePath.replace(/\.mbtp?$/, '.svg')
       : `${relativePath}.svg`;
     return resolve('artifacts/previews', fixtureRelativePath);
   }
 
-  const previewName = sourcePath.endsWith('.mbt')
-    ? `${basename(sourcePath).replace(/\.mbt$/, '')}-preview.svg`
+  const previewName = sourcePath.endsWith('.mbt') || sourcePath.endsWith('.mbtp')
+    ? `${basename(sourcePath).replace(/\.mbtp?$/, '')}-preview.svg`
     : `${basename(sourcePath)}-preview.svg`;
   return resolve('artifacts', previewName);
 }

--- a/src/moonbit-config.monogram.ts
+++ b/src/moonbit-config.monogram.ts
@@ -12,23 +12,25 @@ const decimal = String.raw`${digit}[0-9_]*`;
 const escape = String.raw`\\(?:['"\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]+\}|.)`;
 const identStart = String.raw`[a-zA-Z_\u0080-\uFFFF]`;
 const identContinue = String.raw`[a-zA-Z0-9_\u0080-\uFFFF]`;
-
 const ConfigLineComment = token(/\/\/[^\n]*/, {
   skip: true,
   scope: 'comment.line.double-slash',
 });
 const ConfigPackageAlias = token(new RegExp(String.raw`@${identStart}${identContinue}*(?:\/${identStart}${identContinue}*)*`), {
   scope: 'entity.name.namespace',
+  operandStart: true,
 });
 const ConfigString = token(new RegExp(String.raw`"(?:[^"\\\n]|${escape})*"`), {
   string: true,
   escape: new RegExp(escape),
   escapeValid: new RegExp(escape),
   scope: 'string.quoted.double',
+  propertyName: true,
 });
 const ConfigInt = token(new RegExp(decimal), { scope: 'constant.numeric.integer' });
 const ConfigIdent = token(new RegExp(String.raw`${identStart}${identContinue}*`), {
   identifier: true,
+  propertyName: true,
 });
 
 const ConfigBarePath = rule($ => [
@@ -89,11 +91,11 @@ const ConfigApplyDecl = rule($ => [
 
 const ConfigModuleDecl = rule($ => [
   ['module', ConfigString],
-]);
+], { namespace: true });
 
 const ConfigPackageDecl = rule($ => [
   ['package', ConfigBarePath],
-]);
+], { namespace: true });
 
 const ConfigStatement = rule($ => [
   ConfigImportDecl,
@@ -151,5 +153,6 @@ export default defineGrammar({
     'punctuation.separator.path': ['/'],
     'punctuation.terminator.statement': [';'],
   },
+  fileTypes: ['moon.pkg', 'moon.mod'],
   entry: ConfigProgram,
 });

--- a/src/moonbit.monogram.ts
+++ b/src/moonbit.monogram.ts
@@ -28,6 +28,8 @@ const escape = String.raw`\\(?:['"\\nrtbf/ ]|x[0-9a-fA-F]{2}|o[0-3][0-7]{2}|u[0-
 const interpolatedChunk = String.raw`\\\{(?:[^{}\n"'\\]|${escape}|"(?:[^"\\\n]|${escape})*"|'(?:[^'\\\n]|${escape})*'|\{[^{}\n]*\})*\}`;
 const identStart = String.raw`[a-zA-Z_\u0080-\uFFFF]`;
 const identContinue = String.raw`[a-zA-Z0-9_\u0080-\uFFFF]`;
+const lowerIdentStart = String.raw`[a-z_\u0080-\uFFFF]`;
+const upperIdent = String.raw`[A-Z][A-Za-z0-9_]*\??`;
 
 // Comments and attributes come first so they cannot be split into punctuation plus identifiers.
 const DocComment = token(/\/\/\/[^\n]*/, { skip: true, scope: 'comment.line.documentation' });
@@ -49,6 +51,7 @@ const ProofLabel = token(/proof_(?:require|ensure|invariant|yield|decrease|reaso
 const DotInt = token(/\.[0-9]+/, { scope: 'constant.numeric.integer.tuple-index' });
 const PackageName = token(new RegExp(String.raw`@${identStart}${identContinue}*(?:\/${identStart}${identContinue}*)*`), {
   scope: 'entity.name.namespace',
+  operandStart: true,
 });
 const Float = token(new RegExp(`(?:${floatHex}|${floatDec})`), { scope: 'constant.numeric.float' });
 const Double = token(new RegExp(`(?:${doubleHex}|${doubleDec})`), { scope: 'constant.numeric.double' });
@@ -71,26 +74,28 @@ const MultilineInterp = token(/\$\|[^\n]*/, { scope: 'string.quoted.other.multil
 const MultilineString = token(/#\|[^\n]*/, { scope: 'string.quoted.other.multiline' });
 const Byte = token(new RegExp(String.raw`b'(?:${escape}|[^\\'\n])+'`), { scope: 'constant.character.byte' });
 const Char = token(new RegExp(String.raw`'(?:${escape}|[^\\'\n])+'`), { scope: 'constant.character' });
-const Ident = token(new RegExp(String.raw`${identStart}${identContinue}*`), { identifier: true });
+const UIdent = token(new RegExp(upperIdent), { scope: 'entity.name.type', typeName: true });
+const Ident = token(new RegExp(String.raw`${lowerIdentStart}${identContinue}*`), { identifier: true });
 
 const SimplePath = rule($ => [
   Ident,
   [PackageName, '.', Ident],
+  [PackageName, '.', UIdent],
   [$, '.', Ident],
 ]);
 
 const TypeName = rule($ => [
-  Ident,
-  ['&', Ident],
-  [PackageName, '.', Ident],
-  ['&', PackageName, '.', Ident],
-  [TypeName, '::', Ident],
+  UIdent,
+  ['&', UIdent],
+  [PackageName, '.', UIdent],
+  ['&', PackageName, '.', UIdent],
+  [TypeName, '::', UIdent],
 ]);
 
 const TypeParam = rule($ => [
-  Ident,
+  UIdent,
   '_',
-  [Ident, ':', sep(Type, '+')],
+  [UIdent, ':', sep(Type, '+')],
 ]);
 
 const TypeParams = rule($ => [
@@ -167,6 +172,10 @@ const Literal = rule($ => [
   'false',
 ]);
 
+const MultilineLiteral = rule($ => [
+  [alt(MultilineString, MultilineInterp), many(alt(MultilineString, MultilineInterp))],
+]);
+
 const ArrayItem = rule($ => [
   ['..', Expr],
   Expr,
@@ -208,7 +217,7 @@ const LexPattern = rule($ => [
   RegexLiteral,
   StringLiteral,
   TypeName,
-  [PackageName, '.', Ident],
+  [PackageName, '.', UIdent],
   [RegexLiteral, 'as', Binder],
   [$, 'as', Binder],
   [$, '|', $],
@@ -235,14 +244,20 @@ const RegexMatchItem = rule($ => [
 ]);
 
 const Expr = rule($ => [
+  MultilineLiteral,
   Literal,
   SimplePath,
+  UIdent,
+  [UIdent, '::', Ident],
+  [UIdent, '::', UIdent],
   [Forall, Binder, ':', Type, ',', $],
   [Exists, Binder, ':', Type, ',', $],
-  ['&', Ident, '::', Ident],
-  ['&', PackageName, '.', Ident, '::', Ident],
+  ['&', UIdent, '::', Ident],
+  ['&', PackageName, '.', UIdent, '::', Ident],
   [TypeName, '::', Ident],
+  [TypeName, '::', UIdent],
   [TypeName, '::', PackageName, '.', Ident],
+  [TypeName, '::', PackageName, '.', UIdent],
   '_',
   ['...'],
   ['...', $],
@@ -326,9 +341,13 @@ const Pattern = rule($ => [
   ['-', Int],
   ['-', Float],
   ['-', Double],
-  [PackageName, '.', Ident],
+  [PackageName, '.', UIdent],
+  [UIdent, '::', Ident],
+  [UIdent, '::', UIdent],
   [TypeName, '::', Ident],
+  [TypeName, '::', UIdent],
   [TypeName, '::', PackageName, '.', Ident],
+  [TypeName, '::', PackageName, '.', UIdent],
   [$, 'as', Binder],
   [$, '|', $],
   [$, '..<', $],
@@ -337,8 +356,8 @@ const Pattern = rule($ => [
   ['(', sep($, ','), ')'],
   ['[', sep($, ','), ']'],
   ['{', sep(PatternField, ','), '}'],
-  [Ident, '(', sep(PatternArgument, ','), ')'],
-]);
+  [UIdent, '(', sep(PatternArgument, ','), ')'],
+], { binding: true });
 
 const PatternArgument = rule($ => [
   ['..'],
@@ -374,13 +393,16 @@ const Visibility = rule($ => [
 ]);
 
 const Derive = rule($ => [
-  ['derive', opt('(', sep(Ident, ','), ')')],
+  ['derive', opt('(', sep(TypeName, ','), ')')],
 ]);
 
 const FunName = rule($ => [
   Ident,
   [Ident, '::', Ident],
+  [UIdent, '::', Ident],
+  [UIdent, '::', UIdent],
   [TypeName, '::', Ident],
+  [TypeName, '::', UIdent],
 ]);
 
 const FunDecl = rule($ => [
@@ -404,23 +426,23 @@ const ValDecl = rule($ => [
 ]);
 
 const TypeHeader = rule($ => [
-  [many(Attribute), opt('declare'), opt(Visibility), alt('type', 'struct', 'enum', 'extenum', 'suberror'), opt('!'), Ident, opt(TypeParams)],
+  [many(Attribute), opt('declare'), opt(Visibility), alt('type', 'struct', 'enum', 'extenum', 'suberror'), opt('!'), UIdent, opt(TypeParams)],
 ]);
 
 const TypeDecl = rule($ => [
   [TypeHeader, TypeBody, opt(Derive)],
   [TypeHeader, '=', Type, opt(Derive)],
   [TypeHeader, opt(Derive)],
-  [many(Attribute), opt(Visibility), 'extenum', PackageName, '.', Ident, opt(TypeParams), '+=', '{', many(TypeMember), '}', opt(Derive)],
-  [many(Attribute), opt(Visibility), 'enumview', opt(TypeParams), Ident, '{', many(TypeMember), '}', 'for', Type, 'with', Ident, Params, Block],
+  [many(Attribute), opt(Visibility), 'extenum', PackageName, '.', UIdent, opt(TypeParams), '+=', '{', many(TypeMember), '}', opt(Derive)],
+  [many(Attribute), opt(Visibility), 'enumview', opt(TypeParams), UIdent, '{', many(TypeMember), '}', 'for', Type, 'with', Ident, Params, Block],
   [many(Attribute), opt('declare'), opt(Visibility), 'typealias', TypeAliasTarget],
-  [many(Attribute), opt(Visibility), 'traitalias', Ident, '=', TypeName],
+  [many(Attribute), opt(Visibility), 'traitalias', UIdent, '=', TypeName],
   [many(Attribute), opt(Visibility), 'fnalias', FunAliasTarget],
 ]);
 
 const TypeAliasTarget = rule($ => [
-  [TypeName, opt('as', Ident)],
-  [PackageName, '.', Ident, opt('as', Ident)],
+  [TypeName, opt('as', UIdent)],
+  [PackageName, '.', UIdent, opt('as', UIdent)],
   [PackageName, '.', '(', sep(TypeName, ','), ')'],
 ]);
 
@@ -438,14 +460,14 @@ const TypeBody = rule($ => [
 
 const TypeMember = rule($ => [
   [many(Attribute), opt(Visibility), opt('mut'), Ident, ':', Type],
-  [many(Attribute), Ident, '(', sep(Type, ','), ')'],
-  [many(Attribute), Ident, opt(Params), opt(':', Type)],
-  [many(Attribute), Ident, opt(TypeArgs), opt(Params)],
+  [many(Attribute), UIdent, '(', sep(Type, ','), ')'],
+  [many(Attribute), UIdent, opt(Params), opt(':', Type)],
+  [many(Attribute), UIdent, opt(TypeArgs), opt(Params)],
   ['..', StringLiteral],
 ]);
 
 const TraitDecl = rule($ => [
-  [many(Attribute), opt(Visibility), 'trait', Ident, opt(TypeParams), opt(':', sep(Type, '+')), TraitBody],
+  [many(Attribute), opt(Visibility), 'trait', UIdent, opt(TypeParams), opt(':', sep(Type, '+')), TraitBody],
 ]);
 
 const TraitMethod = rule($ => [
@@ -562,6 +584,7 @@ export default defineGrammar({
     MultilineString,
     Byte,
     Char,
+    UIdent,
     Ident,
   },
   prec: [
@@ -597,6 +620,7 @@ export default defineGrammar({
     AttributeArgument,
     Attribute,
     Literal,
+    MultilineLiteral,
     ArrayItem,
     MapKey,
     RecordField,
@@ -670,9 +694,8 @@ export default defineGrammar({
     'punctuation.terminator.statement': [';'],
     'constant.language.boolean.true': ['true'],
     'constant.language.boolean.false': ['false'],
-    'support.type.primitive': ['Unit', 'Bool', 'Byte', 'Char', 'Int', 'Int64', 'UInt', 'UInt64', 'Float', 'Double', 'String', 'Bytes'],
-    'support.class': ['Eq', 'Compare', 'Hash', 'Show', 'Default', 'ToJson', 'FromJson', 'Error'],
   },
+  fileTypes: ['mbt', 'mbtx', 'mbtp'],
   entry: Program,
   expression: Expr,
 });

--- a/src/moonbit.monogram.ts
+++ b/src/moonbit.monogram.ts
@@ -39,6 +39,12 @@ const AttributeName = token(/#[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)
 const TryQuestion = token(/try\?/, { scope: 'keyword.control.exception' });
 const TryBang = token(/try!/, { scope: 'keyword.control.exception' });
 const LexmatchQuestion = token(/lexmatch\?/, { scope: 'keyword.control.conditional' });
+const Forall = token(/∀/, { scope: 'keyword.operator.quantifier' });
+const Exists = token(/∃/, { scope: 'keyword.operator.quantifier' });
+const Implies = token(/→/, { scope: 'keyword.operator.logical.implication' });
+const ProofLabel = token(/proof_(?:require|ensure|invariant|yield|decrease|reasoning|axiomatized)(?=\s*:)/, {
+  scope: 'keyword.other.proof-label',
+});
 
 const DotInt = token(/\.[0-9]+/, { scope: 'constant.numeric.integer.tuple-index' });
 const PackageName = token(new RegExp(String.raw`@${identStart}${identContinue}*(?:\/${identStart}${identContinue}*)*`), {
@@ -177,9 +183,14 @@ const RecordField = rule($ => [
   ['..', Expr],
   [MapKey, ':', Expr],
   [StringLiteral, ':', Expr],
+  [ProofLabel, ':', Expr],
   [Ident, ':', Expr],
   [Ident, '=', Expr],
   Ident,
+]);
+
+const ProofWhereClause = rule($ => [
+  ['where', '{', sep(RecordField, ','), '}'],
 ]);
 
 const MatchCase = rule($ => [
@@ -226,6 +237,8 @@ const RegexMatchItem = rule($ => [
 const Expr = rule($ => [
   Literal,
   SimplePath,
+  [Forall, Binder, ':', Type, ',', $],
+  [Exists, Binder, ':', Type, ',', $],
   ['&', Ident, '::', Ident],
   ['&', PackageName, '.', Ident, '::', Ident],
   [TypeName, '::', Ident],
@@ -236,6 +249,7 @@ const Expr = rule($ => [
   [prefix, $],
   [TryQuestion, $],
   [TryBang, $],
+  [$, Implies, $],
   [$, op, $],
   [$, '?', $, ':', $],
   [$, DotInt],
@@ -370,8 +384,8 @@ const FunName = rule($ => [
 ]);
 
 const FunDecl = rule($ => [
-  [many(Attribute), opt('declare'), opt('extern', opt(StringLiteral)), opt(Visibility), opt('async'), 'fn', opt(TypeParams), FunName, opt('!'), opt(TypeParams), opt(Params), opt(ReturnType), DeclBody],
-  [many(Attribute), opt('declare'), opt('extern', opt(StringLiteral)), opt(Visibility), opt('async'), 'fn', FunName, opt('!'), opt(TypeParams), opt(Params), opt(ReturnType), DeclBody],
+  [many(Attribute), opt('declare'), opt('extern', opt(StringLiteral)), opt(Visibility), opt('async'), 'fn', opt(TypeParams), FunName, opt('!'), opt(TypeParams), opt(Params), opt(ReturnType), opt(ProofWhereClause), DeclBody],
+  [many(Attribute), opt('declare'), opt('extern', opt(StringLiteral)), opt(Visibility), opt('async'), 'fn', FunName, opt('!'), opt(TypeParams), opt(Params), opt(ReturnType), opt(ProofWhereClause), DeclBody],
 ]);
 
 const DeclBody = rule($ => [
@@ -458,6 +472,7 @@ const ImplDecl = rule($ => [
 const ImplBody = rule($ => [
   ['{', many(alt(FunDecl, ValDecl, TypeDecl)), '}'],
   FunDecl,
+  [Ident, opt('!'), Params, opt(ReturnType), DeclBody],
   [';'],
 ]);
 
@@ -469,6 +484,19 @@ const ImportDecl = rule($ => [
 
 const TestDecl = rule($ => [
   [many(Attribute), opt('async'), 'test', opt(StringLiteral), opt(Params), Block],
+]);
+
+const PredicateDecl = rule($ => [
+  [many(Attribute), opt(Visibility), 'predicate', opt(TypeParams), FunName, opt('!'), opt(TypeParams), opt(Params), opt(ProofWhereClause), DeclBody],
+]);
+
+const LemmaDecl = rule($ => [
+  [many(Attribute), opt(Visibility), 'lemma', opt(TypeParams), FunName, opt('!'), opt(TypeParams), opt(Params), opt(ProofWhereClause), alt(Block, [';'])],
+]);
+
+const ProofStmt = rule($ => [
+  ['proof_assert', Expr],
+  ['proof_let', Binder, '=', Expr],
 ]);
 
 const ControlStmt = rule($ => [
@@ -485,6 +513,8 @@ const AssignStmt = rule($ => [
 ]);
 
 const Stmt = rule($ => [
+  PredicateDecl,
+  LemmaDecl,
   FunDecl,
   ValDecl,
   TypeDecl,
@@ -492,6 +522,7 @@ const Stmt = rule($ => [
   ImplDecl,
   ImportDecl,
   TestDecl,
+  ProofStmt,
   ControlStmt,
   AssignStmt,
   Expr,
@@ -515,6 +546,10 @@ export default defineGrammar({
     TryQuestion,
     TryBang,
     LexmatchQuestion,
+    Forall,
+    Exists,
+    Implies,
+    ProofLabel,
     DotInt,
     PackageName,
     Float,
@@ -565,6 +600,7 @@ export default defineGrammar({
     ArrayItem,
     MapKey,
     RecordField,
+    ProofWhereClause,
     MatchCase,
     ForBinding,
     LexPattern,
@@ -597,6 +633,9 @@ export default defineGrammar({
     ImplBody,
     ImportDecl,
     TestDecl,
+    PredicateDecl,
+    LemmaDecl,
+    ProofStmt,
     ControlStmt,
     AssignStmt,
     Stmt,
@@ -609,9 +648,10 @@ export default defineGrammar({
     'keyword.control.flow': ['return', 'raise', 'throw', 'defer'],
     'keyword.control.exception': ['try', 'catch'],
     'keyword.control.import': ['import', 'using'],
-    'storage.type.function': ['fn'],
+    'storage.type.function': ['fn', 'predicate', 'lemma'],
     'storage.type': ['let', 'letrec', 'const', 'type', 'struct', 'enum', 'enumview', 'extenum', 'trait', 'impl', 'typealias', 'traitalias', 'fnalias', 'suberror', 'test'],
     'storage.modifier': ['pub', 'priv', 'readonly', 'extern', 'mut', 'async', 'declare', 'noraise', 'nobreak'],
+    'keyword.control.proof': ['proof_assert', 'proof_let'],
     'keyword.operator.expression': ['as', 'is', 'not'],
     'keyword.operator.assignment': ['=', '+=', '-=', '*=', '/=', '%='],
     'keyword.operator.comparison': ['==', '!=', '<', '>', '<=', '>=', '=~'],

--- a/tests/fixtures/async-fs-text-file-test.mbt
+++ b/tests/fixtures/async-fs-text-file-test.mbt
@@ -1,0 +1,27 @@
+// SYNTAX TEST "source.moonbit" "async fs text_file_test"
+// Source: /Users/baozhiyuan/Workspace/async/src/fs/text_file_test.mbt
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "text file" {
+// <- storage.modifier.moonbit
+//    ^^^^ storage.type.moonbit
+  @async.with_task_group() <| root => {
+    let path = "_build/basic_text_file_test"
+    root.add_defer(() => @fs.remove(path))
+    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate)
+    inspect(@fs.read_file(path).text(), content="abcd")
+  }
+}

--- a/tests/fixtures/async-mutex-test.mbt
+++ b/tests/fixtures/async-mutex-test.mbt
@@ -1,0 +1,108 @@
+// SYNTAX TEST "source.moonbit" "async mutex_test"
+// Source: /Users/baozhiyuan/Workspace/async/src/mutex_test.mbt
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "mutex basic" {
+// <- storage.modifier.moonbit
+//    ^^^^ storage.type.moonbit
+  let log = []
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    for i in 0..<3 {
+      group.spawn_bg() <| () => {
+        mutex.acquire()
+        log.push("task \{i} acquired mutex")
+        @async.sleep(300)
+        mutex.release()
+      }
+    }
+    @async.sleep(150)
+    for _ in 0..<3 {
+      log.push("tick")
+      @async.sleep(300)
+    }
+  }
+  json_inspect(log, content=[
+    "task 0 acquired mutex", "tick", "task 1 acquired mutex", "tick", "task 2 acquired mutex",
+    "tick",
+  ])
+}
+
+///|
+async test "mutex cancellation" {
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    group.spawn_bg() <| () => {
+      mutex.acquire()
+      @async.sleep(500)
+      mutex.release()
+    }
+    debug_inspect(
+      try? @async.with_timeout(250, () => mutex.acquire()),
+      content="Err(TimeoutError)",
+    )
+    @async.sleep(500)
+    inspect(mutex.try_acquire(), content="true")
+  }
+}
+
+///|
+async test "mutex cancellation no_swallow" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    mutex.acquire()
+    let acquire_taskire_task = group.spawn(() => {
+      mutex.acquire()
+      log.push("acquire() succeed")
+    })
+    @async.sleep(100)
+    mutex.release()
+    acquire_taskire_task.cancel()
+    @async.sleep(100)
+    inspect(mutex.try_acquire(), content="false")
+  }
+  json_inspect(log, content=["acquire() succeed"])
+}
+
+///|
+async test "mutex fairness" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    group.spawn_bg() <| () => {
+      for _ in 0..<3 {
+        mutex.acquire()
+        log.push("task 1 acquired mutex")
+        @async.sleep(200)
+        mutex.release()
+      }
+    }
+    group.spawn_bg() <| () => {
+      @async.sleep(100)
+      for _ in 0..<3 {
+        mutex.acquire()
+        log.push("task 2 acquired mutex")
+        @async.sleep(200)
+        mutex.release()
+      }
+    }
+  }
+  json_inspect(log, content=[
+    "task 1 acquired mutex", "task 2 acquired mutex", "task 1 acquired mutex", "task 2 acquired mutex",
+    "task 1 acquired mutex", "task 2 acquired mutex",
+  ])
+}

--- a/tests/fixtures/async-spawn-test.mbt
+++ b/tests/fixtures/async-spawn-test.mbt
@@ -1,0 +1,76 @@
+// SYNTAX TEST "source.moonbit" "async spawn_test"
+// Source: /Users/baozhiyuan/Workspace/async/src/spawn_test.mbt
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "spawn error1" {
+// <- storage.modifier.moonbit
+//    ^^^^ storage.type.moonbit
+  let buf = StringBuilder::new()
+  let result = try? @async.with_task_group(root => {
+    root.spawn_bg() <| () => {
+      @async.sleep(1000)
+      buf <+ "task 1 finished\n"
+    }
+    root.spawn_bg() <| () => {
+      @async.sleep(200)
+      raise Err
+//    ^^^^^ keyword.control.flow.moonbit
+//          ^^^ entity.name.type.moonbit
+    }
+  })
+  buf.write_string(@debug.to_string(result))
+  inspect(buf.to_string(), content="Err(Err)")
+}
+
+///|
+async test "spawn error2" {
+  let buf = StringBuilder::new()
+  let result = try? @async.with_task_group(root => {
+    root.spawn_bg() <| () => {
+      @async.sleep(200)
+      raise Err
+    }
+    root.spawn_bg() <| () => {
+      @async.sleep(1000)
+      buf <+ "task 1 finished\n"
+    }
+  })
+  buf.write_string(@debug.to_string(result))
+  inspect(buf.to_string(), content="Err(Err)")
+}
+
+///|
+async test "spawn after cancelled" {
+  let log = []
+  let _ : Result[Unit, _] = try? @async.with_task_group(group => {
+    group.spawn_bg() <| () => {
+      // emulate a non-cancellable job,
+      // or a job that happens to be completed on cancellation,
+      // such that discarding the result may lead to data loss
+      @async.protect_from_cancel(() => @async.sleep(300), resume_on_cancel=true)
+      // even if control flow enters here normally,
+      // current task and the whole group may be in a cancelled state
+      group.spawn_bg(allow_failure=true) <| () => {
+        log.push("enter child task after cancelled")
+        @async.sleep(100)
+        log.push("child task completed")
+      }
+    }
+    @async.sleep(150)
+    raise Failure::Failure("failure")
+  })
+  json_inspect(log, content=["enter child task after cancelled"])
+}

--- a/tests/fixtures/core-builtin-guard-feature-test.mbt
+++ b/tests/fixtures/core-builtin-guard-feature-test.mbt
@@ -1,0 +1,58 @@
+// SYNTAX TEST "source.moonbit" "core builtin guard_feature_test"
+// Source: /Users/baozhiyuan/Workspace/core/builtin/guard_feature_test.mbt
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+enum Expr {
+// <- storage.type.moonbit
+//   ^^^^ entity.name.type.moonbit
+  Add(Expr, Expr)
+  Sub(Expr, Expr)
+  Mul(Expr, Expr)
+  Div(Expr, Expr)
+  Lit(Int)
+  Var(String)
+} derive(Debug, ToJson, Eq)
+
+///|
+fn simplify(e : Expr) -> Expr {
+// <- storage.type.function.moonbit
+// ^^^^^^^^ entity.name.function.moonbit
+  match e {
+    Add(e1, Lit(0)) => simplify(e1)
+    Add(Lit(0), e2) => simplify(e2)
+    Mul(e1, Lit(1)) => simplify(e1)
+    Mul(Lit(1), e2) => simplify(e2)
+    Sub(e1, e2) if e1 == e2 => Lit(0)
+    // guard is useful for in-exhaustive match
+    // otherwise the else condition will be duplicated
+    Mul(Lit(0), _) => Lit(0)
+    Mul(_, Lit(0)) => Lit(0)
+    _ => e
+  }
+}
+
+///|
+test "simplify" {
+  let _ignored = Add(Div(Lit(1), Lit(2)), Div(Lit(1), Lit(2)))
+  let e = Sub(Mul(Lit(1), Var("x")), Mul(Lit(1), Var("x")))
+  @json.json_inspect(e, content=[
+    "Sub",
+    ["Mul", ["Lit", 1], ["Var", "x"]],
+    ["Mul", ["Lit", 1], ["Var", "x"]],
+  ])
+  let simplified = simplify(e)
+  @json.json_inspect(simplified, content=["Lit", 0])
+}

--- a/tests/fixtures/core-bytes-feature-pipe-test.mbt
+++ b/tests/fixtures/core-bytes-feature-pipe-test.mbt
@@ -1,0 +1,44 @@
+// SYNTAX TEST "source.moonbit" "core bytes feature_pipe_test"
+// Source: /Users/baozhiyuan/Workspace/core/bytes/feature_pipe_test.mbt
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "feature pipe" {
+// <- storage.type.moonbit
+  let b : Bytes = b"hello"
+  let mut u = Bytes::new(b.length())
+  let v = b
+    |> x => {
+//  ^^ keyword.operator.pipe.moonbit
+      u = x
+      x
+    }
+    |> Bytes::length() // test _.length()
+//  ^^ keyword.operator.pipe.moonbit
+    |> Int::to_int64() // test _.to_int()
+  inspect(v, content="5")
+  inspect(
+    b,
+    content=(
+      #|b"hello"
+    ),
+  )
+  inspect(
+    u,
+    content=(
+      #|b"hello"
+    ),
+  )
+}

--- a/tests/fixtures/core-bytes-view-pattern-test.mbt
+++ b/tests/fixtures/core-bytes-view-pattern-test.mbt
@@ -1,0 +1,25 @@
+// SYNTAX TEST "source.moonbit" "core bytes view_pattern_test"
+// Source: /Users/baozhiyuan/Workspace/core/bytes/view_pattern_test.mbt
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "View::pattern" {
+// <- storage.type.moonbit
+  let view = b"\x01\x02\x03"[:]
+  match view {
+    [0x01, 0x02, .. rest] => inspect(rest, content="b\"\\x03\"")
+    _ => abort("should not happen")
+  }
+}

--- a/tests/fixtures/core-cmp-reverse.mbt
+++ b/tests/fixtures/core-cmp-reverse.mbt
@@ -6,7 +6,9 @@
 /// `Reverse[T]` is useful when you need to reverse the natural ordering of a type.
 #warnings("-deprecated_syntax")
 // <- entity.name.function.decorator.moonbit
-// <~~~~~~~~~~- string.quoted.double.moonbit
+//        ^ punctuation.definition.string.begin.moonbit
+//         ^^^^^^^^^^^^^^^^^^ string.quoted.double.moonbit
+//                           ^ punctuation.definition.string.end.moonbit
 pub(all) struct Reverse[T](T) derive(Eq, Show, Hash, @debug.Debug)
 // <- storage.modifier.moonbit
 //       ^^^^^^ storage.type.moonbit

--- a/tests/fixtures/core-unit-default.mbt
+++ b/tests/fixtures/core-unit-default.mbt
@@ -4,7 +4,9 @@
 /// same as `Unit::default`
 #deprecated("Use `Unit::default` instead")
 // <- entity.name.function.decorator.moonbit
-// <~~~~~~~~~~~~- string.quoted.double.moonbit
+//          ^ punctuation.definition.string.begin.moonbit
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.moonbit
+//                                      ^ punctuation.definition.string.end.moonbit
 pub fn default() -> Unit {
 // <- storage.modifier.moonbit
 //  ^^ storage.type.function.moonbit

--- a/tests/fixtures/core-value-range.mbt
+++ b/tests/fixtures/core-value-range.mbt
@@ -4,7 +4,9 @@
 /// Number-of-values constraint for an argument.
 #warnings("-deprecated_syntax-deprecated")
 // <- entity.name.function.decorator.moonbit
-// <~~~~~~~~~~- string.quoted.double.moonbit
+//        ^ punctuation.definition.string.begin.moonbit
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.moonbit
+//                                      ^ punctuation.definition.string.end.moonbit
 pub struct ValueRange {
 // <- storage.modifier.moonbit
 //  ^^^^^^ storage.type.moonbit

--- a/tests/fixtures/generated-source.mbt
+++ b/tests/fixtures/generated-source.mbt
@@ -1,0 +1,67 @@
+// SYNTAX TEST "source.moonbit" "generated source multiline interpolation"
+fn generated_source(
+// <- storage.type.function.moonbit
+// ^^^^^^^^^^^^^^^^ entity.name.function.moonbit
+  base~ : String,
+//^^^^ variable.other.readwrite.moonbit
+//        ^^^^^^ entity.name.type.moonbit
+  function_name~ : String,
+//^^^^^^^^^^^^^ variable.other.readwrite.moonbit
+//                 ^^^^^^ entity.name.type.moonbit
+  markdown~ : String,
+//^^^^^^^^ variable.other.readwrite.moonbit
+//            ^^^^^^ entity.name.type.moonbit
+) -> String {
+//^^ storage.type.function.arrow.moonbit
+//   ^^^^^^ entity.name.type.moonbit
+  let lines: Iter[StringView] = markdown.split("\n")
+//^^^ storage.type.moonbit
+//    ^^^^^ variable.other.moonbit
+//           ^^^^ entity.name.type.moonbit
+//                ^^^^^^^^^^ entity.name.type.moonbit
+//                                       ^^^^^ entity.name.function.moonbit
+//                                              ^^ constant.character.escape.moonbit
+  (
+    $|// Generated from \{base} by moon dev_build. DO NOT EDIT.
+//  ^^ punctuation.definition.string.begin.moonbit
+//                      ^^ punctuation.definition.template-expression.begin.moonbit
+//                        ^^^^ variable.other.readwrite.moonbit
+//                            ^ punctuation.definition.template-expression.end.moonbit
+    $|///|
+//  ^^ punctuation.definition.string.begin.moonbit
+//    ^^^^ string.quoted.other.multiline.interpolated.moonbit
+    $|fn \{function_name}() -> String {
+//  ^^ punctuation.definition.string.begin.moonbit
+//       ^^ punctuation.definition.template-expression.begin.moonbit
+//         ^^^^^^^^^^^^^ variable.other.readwrite.moonbit
+//                      ^ punctuation.definition.template-expression.end.moonbit
+    $|  (
+//  ^^ punctuation.definition.string.begin.moonbit
+//    ^^^ string.quoted.other.multiline.interpolated.moonbit
+    $|\{out => for line in lines { out <+ str"    #|\{line}\n" }}  )
+//  ^^ punctuation.definition.string.begin.moonbit
+//    ^^ punctuation.definition.template-expression.begin.moonbit
+//      ^^^ variable.other.readwrite.moonbit
+//          ^^ storage.type.function.arrow.moonbit
+//             ^^^ keyword.control.loop.moonbit
+//                 ^^^^ variable.other.readwrite.moonbit
+//                      ^^ keyword.control.loop.moonbit
+//                         ^^^^^ variable.other.readwrite.moonbit
+//                                     ^ keyword.operator.comparison.moonbit
+//                                      ^ keyword.operator.arithmetic.moonbit
+//                                        ^^^ variable.other.readwrite.moonbit
+//                                           ^ punctuation.definition.string.begin.moonbit
+//                                                  ^^ punctuation.definition.template-expression.begin.moonbit
+//                                                    ^^^^ variable.other.readwrite.moonbit
+//                                                        ^ punctuation.definition.template-expression.end.moonbit
+//                                                         ^^ constant.character.escape.moonbit
+//                                                           ^ punctuation.definition.string.end.moonbit
+//                                                             ^ punctuation.definition.block.moonbit
+//                                                              ^ punctuation.definition.template-expression.end.moonbit
+    $|}
+//  ^^ punctuation.definition.string.begin.moonbit
+//    ^ string.quoted.other.multiline.interpolated.moonbit
+    $|
+//  ^^ punctuation.definition.string.begin.moonbit
+  )
+}

--- a/tests/fixtures/handwritten-aliases-extern.mbt
+++ b/tests/fixtures/handwritten-aliases-extern.mbt
@@ -1,7 +1,9 @@
 // SYNTAX TEST "source.moonbit" "handwritten aliases and externs"
 #deprecated("use now")
 // <- entity.name.function.decorator.moonbit
-// <~~~~~~~~~~~~- string.quoted.double.moonbit
+//          ^ punctuation.definition.string.begin.moonbit
+//           ^^^^^^^ string.quoted.double.moonbit
+//                  ^ punctuation.definition.string.end.moonbit
 extern "js" fn runtime_now() -> Double = "Date.now"
 // <- storage.modifier.moonbit
 

--- a/tests/fixtures/handwritten-imports-packages.mbt
+++ b/tests/fixtures/handwritten-imports-packages.mbt
@@ -1,7 +1,9 @@
 // SYNTAX TEST "source.moonbit" "handwritten imports and package paths"
 import "ffi"
 // <- keyword.control.import.moonbit
-//     ^^^^^ string.quoted.double.moonbit
+//     ^ punctuation.definition.string.begin.moonbit
+//      ^^^ string.quoted.double.moonbit
+//         ^ punctuation.definition.string.end.moonbit
 
 using @moonbitlang/core/array(make)
 // <- keyword.control.import.moonbit

--- a/tests/fixtures/handwritten-literals.mbt
+++ b/tests/fixtures/handwritten-literals.mbt
@@ -11,6 +11,9 @@ fn literals {
 // <~~- string.regexp.moonbit
   $|hello \{name}
 // <~~- string.quoted.other.multiline.interpolated.moonbit
+//        ^^ punctuation.definition.template-expression.begin.moonbit
+//          ^^^^ variable.other.readwrite.moonbit
+//              ^ punctuation.definition.template-expression.end.moonbit
   #|raw line
 // <~~- string.quoted.other.multiline.moonbit
 }

--- a/tests/fixtures/handwritten-literals.mbt
+++ b/tests/fixtures/handwritten-literals.mbt
@@ -2,18 +2,28 @@
 fn literals {
 // ^^^^^^^^ entity.name.function.moonbit
   "hello\n" |> ignore()
-// <~~- string.quoted.double.moonbit
+//^ punctuation.definition.string.begin.moonbit
+// ^^^^^ string.quoted.double.moonbit
+//      ^^ constant.character.escape.moonbit
+//        ^ punctuation.definition.string.end.moonbit
   b"bytes" |> ignore()
 // <~~- string.quoted.double.bytes.moonbit
   '🎉' |> ignore()
   b'a' |> ignore()
   re"ab+\{name}" |> ignore()
-// <~~- string.regexp.moonbit
+//^^ string.regexp.moonbit
+//  ^ punctuation.definition.string.begin.moonbit
+//   ^^^ string.regexp.moonbit
+//      ^^ punctuation.definition.template-expression.begin.moonbit - string.regexp.moonbit
+//        ^^^^ variable.other.readwrite.moonbit - string.regexp.moonbit
+//            ^ punctuation.definition.template-expression.end.moonbit - string.regexp.moonbit
+//             ^ punctuation.definition.string.end.moonbit
   $|hello \{name}
-// <~~- string.quoted.other.multiline.interpolated.moonbit
-//        ^^ punctuation.definition.template-expression.begin.moonbit
-//          ^^^^ variable.other.readwrite.moonbit
-//              ^ punctuation.definition.template-expression.end.moonbit
+//^^ punctuation.definition.string.begin.moonbit
+//  ^^^^^^ string.quoted.other.multiline.interpolated.moonbit
+//        ^^ punctuation.definition.template-expression.begin.moonbit - string.quoted.other.multiline.interpolated.moonbit
+//          ^^^^ variable.other.readwrite.moonbit - string.quoted.other.multiline.interpolated.moonbit
+//              ^ punctuation.definition.template-expression.end.moonbit - string.quoted.other.multiline.interpolated.moonbit
   #|raw line
 // <~~- string.quoted.other.multiline.moonbit
 }

--- a/tests/fixtures/language-surface.mbt
+++ b/tests/fixtures/language-surface.mbt
@@ -26,6 +26,9 @@ impl Drawable for Shape with {
   fn draw(self : Shape) -> Unit {
     match self {
       Circle(radius) => println("circle \{radius}")
+//                                      ^^ punctuation.definition.template-expression.begin.moonbit
+//                                        ^^^^^^ variable.other.readwrite.moonbit
+//                                              ^ punctuation.definition.template-expression.end.moonbit
       Rect({ x, y }, _) => println("rect")
     }
   }

--- a/tests/fixtures/list-spread-pattern.mbt
+++ b/tests/fixtures/list-spread-pattern.mbt
@@ -1,0 +1,17 @@
+// SYNTAX TEST "source.moonbit" "list spread and list pattern preview"
+test {
+// <---- storage.type.moonbit
+  let xs = []
+// <~~--- storage.type.moonbit
+  match xs {
+// <~~----- keyword.control.conditional.moonbit
+    [] => ()
+// <~~~~~~~-- storage.type.function.arrow.moonbit
+    [x, .. xs] => ()
+// <~~~~~~~~-- keyword.operator.range.moonbit
+// <~~~~~~~~~~~~~~~-- storage.type.function.arrow.moonbit
+  }
+  let ys = [..xs]
+// <~~--- storage.type.moonbit
+// <~~~~~~~~~~~~-- keyword.operator.range.moonbit
+}

--- a/tests/fixtures/proof-surface.mbtp
+++ b/tests/fixtures/proof-surface.mbtp
@@ -1,0 +1,44 @@
+// SYNTAX TEST "source.moonbit" "proof surface"
+#proof_import("int.Int")
+// <- entity.name.function.decorator.moonbit
+fn MathInt::equal(self : MathInt, other : MathInt) -> Bool = "(=)"
+// <- storage.type.function.moonbit
+
+pub impl Eq for MathInt with equal(self, other) {
+// <- storage.modifier.moonbit
+//  ^^^^ storage.type.moonbit
+  self.equal(other)
+}
+
+pub predicate FixedArray::in_bounds(self : FixedArray[Int], i : Int) {
+// <- storage.modifier.moonbit
+//  ^^^^^^^^^ storage.type.function.moonbit
+  (0 <= i) && (i < self.length())
+}
+
+pub predicate sorted(xs : FixedArray[Int]) {
+  ∀ i : Int, ∃ j : Int, FixedArray::in_bounds(xs, i) → i <= j
+//^ keyword.operator.quantifier.moonbit
+//           ^ keyword.operator.quantifier.moonbit
+//                                                   ^ keyword.operator.logical.implication.moonbit
+}
+
+fn first(xs : FixedArray[Int]) -> Int where {
+  proof_require: sorted(xs),
+//^^^^^^^^^^^^^ keyword.other.proof-label.moonbit
+  proof_ensure: result => FixedArray::in_bounds(xs, result),
+//^^^^^^^^^^^^ keyword.other.proof-label.moonbit
+} {
+  proof_assert ∃ i : Int, FixedArray::in_bounds(xs, i)
+//^^^^^^^^^^^^ keyword.control.proof.moonbit
+  xs[0]
+}
+
+lemma first_in_bounds(xs : FixedArray[Int]) where {
+// <- storage.type.function.moonbit
+  proof_require: sorted(xs),
+  proof_ensure: FixedArray::in_bounds(xs, first(xs)),
+  proof_decrease: xs,
+} {
+  proof_assert sorted(xs)
+}

--- a/tests/fixtures/string-interpolation.mbt
+++ b/tests/fixtures/string-interpolation.mbt
@@ -1,0 +1,46 @@
+// SYNTAX TEST "source.moonbit" "complex string interpolation"
+fn complex_string_interpolation(value : Int, name : String) -> String {
+  let one = "before \{if value > 0 { "inner \{name}" } else { "none" }} after"
+//          ^ string.quoted.double.moonbit punctuation.definition.string.begin.moonbit
+//           ^^^^^^^ string.quoted.double.moonbit
+//                  ^^ punctuation.definition.template-expression.begin.moonbit - string.quoted.double.moonbit
+//                    ^^ keyword.control.conditional.moonbit
+//                                 ^ punctuation.definition.block.moonbit - string.quoted.double.moonbit
+//                                   ^ string.quoted.double.moonbit punctuation.definition.string.begin.moonbit
+//                                    ^^^^^^ string.quoted.double.moonbit
+//                                          ^^ punctuation.definition.template-expression.begin.moonbit - string.quoted.double.moonbit
+//                                            ^^^^ variable.other.readwrite.moonbit - string.quoted.double.moonbit
+//                                                ^ punctuation.definition.template-expression.end.moonbit - string.quoted.double.moonbit
+//                                                   ^ punctuation.definition.block.moonbit - string.quoted.double.moonbit
+//                                                          ^ punctuation.definition.block.moonbit - string.quoted.double.moonbit
+//                                                                   ^ punctuation.definition.block.moonbit - string.quoted.double.moonbit
+//                                                                    ^ punctuation.definition.template-expression.end.moonbit - string.quoted.double.moonbit
+//                                                                     ^^^^^^ string.quoted.double.moonbit
+//                                                                           ^ string.quoted.double.moonbit punctuation.definition.string.end.moonbit
+  let two = $|prefix \{match value { 0 => "zero"; _ => "value \{value}" }} suffix
+//          ^^ string.quoted.other.multiline.interpolated.moonbit punctuation.definition.string.begin.moonbit
+//            ^^^^^^^ string.quoted.other.multiline.interpolated.moonbit
+//                   ^^ punctuation.definition.template-expression.begin.moonbit - string.quoted.other.multiline.interpolated.moonbit
+//                     ^^^^^ keyword.control.conditional.moonbit
+//                                 ^ punctuation.definition.block.moonbit - string.quoted.other.multiline.interpolated.moonbit
+//                                        ^ string.quoted.double.moonbit punctuation.definition.string.begin.moonbit
+//                                         ^^^^ string.quoted.double.moonbit
+//                                                     ^ string.quoted.double.moonbit punctuation.definition.string.begin.moonbit
+//                                                      ^^^^^^ string.quoted.double.moonbit
+//                                                            ^^ punctuation.definition.template-expression.begin.moonbit - string.quoted.double.moonbit string.quoted.other.multiline.interpolated.moonbit
+//                                                              ^^^^^ variable.other.readwrite.moonbit - string.quoted.double.moonbit string.quoted.other.multiline.interpolated.moonbit
+//                                                                   ^ punctuation.definition.template-expression.end.moonbit - string.quoted.double.moonbit string.quoted.other.multiline.interpolated.moonbit
+//                                                                      ^ punctuation.definition.block.moonbit - string.quoted.other.multiline.interpolated.moonbit
+//                                                                       ^ punctuation.definition.template-expression.end.moonbit - string.quoted.other.multiline.interpolated.moonbit
+//                                                                        ^^^^^^^ string.quoted.other.multiline.interpolated.moonbit
+  let three = re"^item-\{value}$"
+//            ^^ string.regexp.moonbit
+//              ^ string.regexp.moonbit punctuation.definition.string.begin.moonbit
+//               ^^^^^^ string.regexp.moonbit
+//                     ^^ punctuation.definition.template-expression.begin.moonbit - string.regexp.moonbit
+//                       ^^^^^ variable.other.readwrite.moonbit - string.regexp.moonbit
+//                            ^ punctuation.definition.template-expression.end.moonbit - string.regexp.moonbit
+//                             ^ string.regexp.moonbit
+//                              ^ string.regexp.moonbit punctuation.definition.string.end.moonbit
+  one + two + three
+}


### PR DESCRIPTION
## What changed

- Moves MoonBit TextMate syntax fixes into the Monogram grammar/source where possible, with `scripts/generate.ts` kept to MoonBit-specific interpolation and `impl ... for ... with` header patches.
- Adds explicit Monogram metadata for binding, namespace declarations, property-name tokens, type-name tokens, operand-start tokens, and file type metadata.
- Updates the MoonBit grammar to use explicit uppercase type identifiers, explicit binding opt-in, config property/namespace metadata, and generated file type associations.
- Fixes string interpolation highlighting so quotes stay string-scoped while interpolation braces and nested block braces are no longer string-scoped.
- Adds regression fixtures/previews for generated-source multiline interpolation and complex string interpolation.

## Why

`src/moonbit.monogram.ts` and `src/moonbit-config.monogram.ts` should be the source of truth for generated TextMate syntax. The generator should not carry MoonBit-specific rewrite hacks except for the two separate post-generation patches we intentionally kept: string interpolation and the `impl` header rule.

## Validation

- `npm test`
- `npm run preview:highlight`
- `git diff --check && git -C vendor/monogram diff --check`

## Notes

This PR updates the `vendor/monogram` submodule pointer to `bzy-debug/monogram@7c46209`, which contains the corresponding Monogram generator/API changes.